### PR TITLE
[CARDBOOK] Prefers encrypting locally cached cards

### DIFF
--- a/user.js
+++ b/user.js
@@ -1519,6 +1519,11 @@ user_pref("mail.collect_email_address_outgoing", false);
  * This could leak sensitive information to all recipients.
  * [SETTING][CARDBOOK] CardBook>Preferences>Email>Sending Emails>Only use email addresses... ***/
 user_pref("extensions.cardbook.useOnlyEmail", true);
+/* 6032: Encrypt locally cached cards [CARDBOOK]
+ * CardBook uses a regular IndexDB to locally cache cards (unencrypted by default).
+ * [SETTING][CARDBOOK] CardBook>Preferences>Advanced>Encryption>Encrypt locally cached cards
+ * [1] https://cardbook.icu/forum/forums/topic/clear-and-easy-storage-and-backup-of-cardbook/#post-2079 ***/
+user_pref("extensions.cardbook.localDataEncryption", true);
 
 /*** [SECTION 6100]: EMAIL COMPOSITION (ENCODING / FORMAT / VIEW)
    Options that relate to composition, formatting and viewing email


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
For CardBook users, enable encryption of locally cached cards.

## Reason and / or context
<!--- Why is this change required ? What problem does it solve ? -->
<!--- If it fixes an open issue, please link to the issue here -->

By default, locally cached cards are being stored **UNENCRYPTED**, possibly leaving whole books accessible on disk.

---

:warning: At the moment, CardBook local cache encryption is still not thorough. Keeping this PR as draft.

From <https://gitlab.com/CardBook/CardBook/-/merge_requests/407#note_132834052> :

> [BUG] New card added to a local addressbook after encryption is activated looks not saved to the indexedDB database. After I restart the card I added goes away.

---

## How has this been tested ?
<!--- Include details of your testing environment here -->
It **DOES NOT** currently universally work.

## Types of changes :
<!--- What types of changes does your code introduce ? Put an `X` in all the boxes that apply : -->
- Bug fix (non-breaking change which fixes an issue)
- Typo / style fix (non-breaking change which improves readability)
- [X] New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- [X] My changes looks good ;
- [X] I agree that my code may be modified in the future ;
- [X] My code follows the code style of this project (see `.eslintrc.yml`).
