### PR TITLE
Thunderbird 91 ESR

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,11 @@ For a more technical breakdown and explanation, you can read more on the [overvi
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-The `thunderbird user.js` is a **template** which aims to provide as much privacy and enhanced security as possible.  
-It differs from the `arkenfox user.js` in that the focus is to keep Thunderbird as an **email client** and disable as many web browsing features as possible. We believe web browsing should be done in a web browser, and not an email client.
+The `thunderbird user.js` is a **template** which aims to provide as much privacy and enhanced security as possible, and to reduce tracking and fingerprinting as much as possible - while minimizing any loss of functionality and breakage (but it will happen).
+
+Everyone, experts included, should at least read the [implementation](https://github.com/HorlogeSkynet/thunderbird-user.js/wiki/1.3-Implementation) wiki page.
+
+It differs from the `arkenfox user.js` in that the focus is to keep Thunderbird as an **e-mail client** and disable as many web browsing features as possible. We believe web browsing should be done in a web browser, and not an email client.
 
 - If you're using Thunderbird (< 68) with Tor we suggest that you install the [TorBirdy](https://addons.thunderbird.net/addon/torbirdy) add-on. If you are using Tor, you should also consider using [Tails](https://tails.boum.org/) or [Whonix](https://www.whonix.org/).
 - If you're using **Gmail**, please check [this article about OAuth2](https://github.com/HorlogeSkynet/thunderbird-user.js/wiki/3.1-OAuth2-Users).

--- a/user.js
+++ b/user.js
@@ -1541,6 +1541,13 @@ user_pref("purple.conversations.im.send_typing", false);
    // user_pref("messenger.startup.action", 0);
 /* 9307: When chat is enabled, do not report idle status ***/
    // user_pref("messenger.status.reportIdle", false);
+/* 9308: Disable chat desktop notifications ***/
+   // user_pref("mail.chat.show_desktop_notifications", false);
+/* 9309: Decide how much information will be shown in chat notifications
+ * 0=Show all info (sender, chat message message preview),
+ * 1=Show sender's info only (not message preview),
+ * 2=No info (fill dummy values). ***/
+user_pref("mail.chat.notification_info", 2);
 
 /** CALENDAR ***/
 /* 9310: Disable calendar integration

--- a/user.js
+++ b/user.js
@@ -1127,6 +1127,8 @@ user_pref("javascript.options.jit_trustedprincipals", true); // [FF75+] [HIDDEN 
  * [2] https://spectrum.ieee.org/tech-talk/telecom/security/more-worries-over-the-security-of-web-assembly
  * [3] https://www.zdnet.com/article/half-of-the-websites-using-webassembly-use-it-for-malicious-purposes ***/
 user_pref("javascript.options.wasm", false);
+/* 5590: show a prompt when opening a link in external applications ***/
+user_pref("security.external_protocol_requires_permission", true);
 
 /*** [SECTION 6000]: DON'T TOUCH ***/
 user_pref("_user.js.parrot", "6000 syntax error: the parrot's 'istory!");

--- a/user.js
+++ b/user.js
@@ -1453,7 +1453,7 @@ user_pref("mail.identity.default.compose_html", false);
 /* 9213: Downgrade email to plaintext by default
  * [SETUP-FEATURE] Only use HTML email if you need it, see above
  * [SETTING] Composition > Composition > HTML Style > Configure text format behavior > Send options... > Send messages as plain text if possible ***/
-user_pref("mailnews.sendformat.auto_downgrade", false);
+user_pref("mailnews.sendformat.auto_downgrade", true);
 /* 9214: What classes can process incoming data.
  * (0=All classes (default), 1=Don't display HTML, 2=Don't display HTML and inline images,
  * 3=Don't display HTML, inline images and some other uncommon types, 100=Use a hard coded list)

--- a/user.js
+++ b/user.js
@@ -1504,6 +1504,13 @@ user_pref("media.hardware-video-decoding.enabled", false);
  * 3=Prevent third-party images from loading
  * [1] http://kb.mozillazine.org/Permissions.default.image ***/
 user_pref("permissions.default.image", 2);
+/* 9240: Builtin phishing/scamming detection
+ * [NOTE] These preferences are enabled by default and should not usually be touched.
+ * [1] https://searchfox.org/comm-central/source/mail/modules/PhishingDetector.jsm ***/
+user_pref("mail.phishing.detection.enabled", true);
+user_pref("mail.phishing.detection.disallow_form_actions", true);
+user_pref("mail.phishing.detection.ipaddresses", true);
+user_pref("mail.phishing.detection.mismatched_hosts", true);
 
 /*** [SECTION 9300]: OTHER THUNDERBIRD COMPONENTS (CHAT / CALENDAR / RSS)
    Options that relate to other Thunderbird components such as the chat client, calendar and RSS)

--- a/user.js
+++ b/user.js
@@ -1351,7 +1351,6 @@ user_pref("mail.showCondensedAddresses", false);
 /* 9112: Disable "Filelink for Large Attachments" feature
  * [1] https://support.thunderbird.net/kb/filelink-large-attachments ***/
 user_pref("mail.cloud_files.enabled", false);
-user_pref("mail.cloud_files.inserted_urls.footer.link", "");
 /* 9113: Don't hide cookies and passwords related (advanced?) buttons ***/
 user_pref("pref.privacy.disable_button.view_cookies", false);
 user_pref("pref.privacy.disable_button.cookie_exceptions", false);

--- a/user.js
+++ b/user.js
@@ -170,7 +170,6 @@ user_pref("datareporting.healthreport.uploadEnabled", false);
  * [2] https://medium.com/georg-fritzsche/data-preference-changes-in-firefox-58-2d5df9c428b5 ***/
 user_pref("toolkit.telemetry.unified", false);
 user_pref("toolkit.telemetry.enabled", false); // see [NOTE]
-user_pref("toolkit.telemetry.prompted", 2);
 user_pref("toolkit.telemetry.server", "data:,");
 user_pref("toolkit.telemetry.archive.enabled", false);
 user_pref("toolkit.telemetry.newProfilePing.enabled", false); // [FF55+]

--- a/user.js
+++ b/user.js
@@ -84,6 +84,10 @@ user_pref("mail.shell.checkDefaultClient", false);
 /* 0102: set START page [SETUP-CHROME]
  * [SETTING] Edit>Preferences>General>Thunderbird Start Page ***/
 user_pref("mailnews.start_page.enabled", false);
+/* 0104: set NEWTAB page
+ * true=Activity Stream (default, see 0105), false=blank page
+ * [SETTING] Home>New Windows and Tabs>New tabs ***/
+user_pref("browser.newtabpage.enabled", false);
 
 /*** [SECTION 0200]: GEOLOCATION / LANGUAGE / LOCALE ***/
 user_pref("_user.js.parrot", "0200 syntax error: the parrot's definitely deceased!");
@@ -793,6 +797,26 @@ user_pref("network.protocol-handler.external.ms-windows-store", false);
  * [1] https://groups.google.com/forum/#!topic/mozilla.dev.platform/BdFOMAuCGW8/discussion ***/
 user_pref("permissions.delegation.enabled", false);
 
+/** DOWNLOADS ***/
+/* 2651: enable user interaction for security by always asking where to download
+ * [SETUP-CHROME] On Android this blocks longtapping and saving images
+ * [SETTING] General>Downloads>Always ask you where to save files ***/
+user_pref("browser.download.useDownloadDir", false);
+/* 2652: disable adding downloads to the system's "recent documents" list ***/
+user_pref("browser.download.manager.addToRecentDocs", false);
+
+/** EXTENSIONS ***/
+/* 2660: lock down allowed extension directories
+ * [SETUP-CHROME] This will break extensions, language packs, themes and any other
+ * XPI files which are installed outside of profile and application directories
+ * [1] https://mike.kaply.com/2012/02/21/understanding-add-on-scopes/
+ * [1] archived: https://archive.is/DYjAM ***/
+user_pref("extensions.enabledScopes", 5); // [HIDDEN PREF]
+user_pref("extensions.autoDisableScopes", 15); // [DEFAULT: 15]
+/* 2662: disable webextension restrictions on certain mozilla domains (you also need 4503) [FF60+]
+ * [1] https://bugzilla.mozilla.org/buglist.cgi?bug_id=1384330,1406795,1415644,1453988 ***/
+   // user_pref("extensions.webextensions.restrictedDomains", "");
+
 /*** [SECTION 2700]: PERSISTENT STORAGE
    Data SET by websites including
           cookies : profile\cookies.sqlite
@@ -1034,6 +1058,11 @@ user_pref("privacy.resistFingerprinting.block_mozAddonManager", true); // [HIDDE
  * [2] https://hg.mozilla.org/mozilla-central/rev/6d2d7856e468#l2.32 ***/
 user_pref("privacy.resistFingerprinting.letterboxing", true); // [HIDDEN PREF]
    // user_pref("privacy.resistFingerprinting.letterboxing.dimensions", ""); // [HIDDEN PREF]
+/* 4505: experimental RFP [FF91+]
+ * [WARNING] DO NOT USE unless testing, see [1] comment 12
+ * [1] https://bugzilla.mozilla.org/1635603 ***/
+   // user_pref("privacy.resistFingerprinting.exemptedDomains", "*.example.invalid");
+   // user_pref("privacy.resistFingerprinting.testGranularityMask", 0);
 
 /*** [SECTION 5000]: OPTIONAL OPSEC
    Disk avoidance, application data isolation, eyeballs...
@@ -1303,6 +1332,12 @@ user_pref("mailnews.start_page_override.mstone", "ignore"); // master switch
 /* UX BEHAVIOR ***/
    // user_pref("general.autoScroll", false); // middle-click enabling auto-scrolling [DEFAULT: false on Linux]
    // user_pref("ui.key.menuAccessKey", 0); // disable alt key toggling the menu bar [RESTART]
+/* UX FEATURES ***/
+   // user_pref("reader.parse-on-load.enabled", false); // Reader View
+/* OTHER ***/
+   // user_pref("browser.bookmarks.max_backups", 2);
+   // user_pref("network.manage-offline-status", false); // see bugzilla 620472
+   // user_pref("xpinstall.signatures.required", false); // enforced extension signing (Nightly/ESR)
 /* RETURN RECEIPT BEHAVIOR ***/
    // user_pref("mail.mdn.report.enabled", false); // disable return receipt sending unconditionally
 /* CUSTOM HEADERS ***/

--- a/user.js
+++ b/user.js
@@ -1,6 +1,6 @@
 /******
 * name: thunderbird user.js
-* date: 17 October 2021
+* date: 30 October 2021
 * version: v91-beta
 * url: https://github.com/HorlogeSkynet/thunderbird-user.js
 * license: MIT (https://github.com/HorlogeSkynet/thunderbird-user.js/blob/master/LICENSE)
@@ -46,7 +46,6 @@
   2000: PLUGINS / MEDIA / WEBRTC
   2300: WEB WORKERS
   2400: DOM (DOCUMENT OBJECT MODEL)
-  2500: FINGERPRINTING
   2600: MISCELLANEOUS
   2700: PERSISTENT STORAGE
   2800: SHUTDOWN
@@ -102,11 +101,12 @@ user_pref("geo.provider.use_gpsd", false); // [LINUX]
 /* 0203: disable region updates
  * [1] https://firefox-source-docs.mozilla.org/toolkit/modules/toolkit_modules/Region.html ***/
 user_pref("browser.region.network.url", ""); // [FF78+]
-user_pref("browser.region.update.enabled", false); // [[FF79+]
+user_pref("browser.region.update.enabled", false); // [FF79+]
 /* 0204: set search region
  * [NOTE] May not be hidden if Thunderbird has changed your settings due to your region (0203) ***/
    // user_pref("browser.search.region", "US"); // [HIDDEN PREF]
-/* 0210: set preferred language for displaying web pages
+/* 0210: set preferred language for displaying pages
+ * [SETTING] General>Language and Appearance>Language>Choose your preferred language...
  * [TEST] https://addons.mozilla.org/about ***/
 user_pref("intl.accept_languages", "en-US, en");
 /* 0210b: Set dictionary to US ***/
@@ -147,9 +147,6 @@ user_pref("extensions.getAddons.cache.enabled", false);
 /* 0306: disable search engine updates (e.g. OpenSearch)
  * [NOTE] This does not affect Mozilla's built-in or Web Extension search engines ***/
 user_pref("browser.search.update", false);
-/* 0307: disable System Add-on updates ***/
-user_pref("extensions.systemAddon.update.enabled", false); // [FF62+]
-user_pref("extensions.systemAddon.update.url", ""); // [FF44+]
 
 /** RECOMMENDATIONS ***/
 /* 0320: disable recommendation pane in about:addons (uses Google Analytics) ***/
@@ -321,13 +318,12 @@ user_pref("network.proxy.socks_remote_dns", true);
  * [SETUP-CHROME] Can break extensions for profiles on network shares
  * [1] https://gitlab.torproject.org/tpo/applications/tor-browser/-/issues/26424 ***/
 user_pref("network.file.disable_unc_paths", true); // [HIDDEN PREF]
-/* 0704: disable GIO as a potential proxy bypass vector
+/* 0704: disable GIO as a potential proxy bypass vector [FF60+]
  * Gvfs/GIO has a set of supported protocols like obex, network, archive, computer, dav, cdda,
  * gphoto2, trash, etc. By default only smb and sftp protocols are accepted so far (as of FF64)
  * [1] https://bugzilla.mozilla.org/1433507
- * [2] https://gitlab.torproject.org/tpo/applications/tor-browser/-/issues/23044
- * [3] https://en.wikipedia.org/wiki/GVfs
- * [4] https://en.wikipedia.org/wiki/GIO_(software) ***/
+ * [2] https://en.wikipedia.org/wiki/GVfs
+ * [3] https://en.wikipedia.org/wiki/GIO_(software) ***/
 user_pref("network.gio.supported-protocols", ""); // [HIDDEN PREF]
 /* 0705: disable DNS-over-HTTPS (DoH) rollout [FF60+]
  * 0=off by default, 2=TRR (Trusted Recursive Resolver) first, 3=TRR only, 5=explicitly off
@@ -337,8 +333,11 @@ user_pref("network.gio.supported-protocols", ""); // [HIDDEN PREF]
  * [3] https://blog.mozilla.org/mozilla/news/firefox-by-default-dns-over-https-rollout-in-canada/
  * [4] https://www.eff.org/deeplinks/2020/12/dns-doh-and-odoh-oh-my-year-review-2020 ***/
    // user_pref("network.trr.mode", 5);
-/* 0706: disable proxy direct failover for system requests [FF91+] ***/
-user_pref("network.proxy.failover_direct", false);
+/* 0706: disable proxy direct failover for system requests [FF91+]
+ * [WARNING] Default true is a security feature against malicious extensions [1]
+ * [SETUP-CHROME] If you use a proxy and you trust your extensions
+ * [1] https://blog.mozilla.org/security/2021/10/25/securing-the-proxy-api-for-firefox-add-ons/ ***/
+   // user_pref("network.proxy.failover_direct", false);
 
 /*** [SECTION 0800]: LOCATION BAR / SEARCH BAR / SUGGESTIONS / HISTORY / FORMS ***/
 user_pref("_user.js.parrot", "0800 syntax error: the parrot's ceased to be!");
@@ -363,14 +362,14 @@ user_pref("browser.fixup.alternate.enabled", false);
  * [SETUP-CHROME] Change these if you trust and use a privacy respecting search engine
  * [SETTING] Search>Provide search suggestions | Show search suggestions in address bar results ***/
 user_pref("browser.search.suggest.enabled", false);
-/* 0808: disable search and form history
+/* 0810: disable search and form history
  * [SETUP-WEB] Be aware that autocomplete form data can be read by third parties [1][2]
  * [NOTE] We also clear formdata on exit (2803)
  * [SETTING] Privacy & Security>History>Custom Settings>Remember search and form history
  * [1] https://blog.mindedsecurity.com/2011/10/autocompleteagain.html
  * [2] https://bugzilla.mozilla.org/381681 ***/
 user_pref("browser.formfill.enable", false);
-/* 0809: disable Form Autofill
+/* 0811: disable Form Autofill
  * [NOTE] Stored data is NOT secure (uses a JSON file)
  * [NOTE] Heuristics controls Form Autofill on forms without @autocomplete attributes
  * [SETTING] Privacy & Security>Forms and Autofill>Autofill addresses
@@ -380,7 +379,7 @@ user_pref("extensions.formautofill.available", "off"); // [FF56+]
 user_pref("extensions.formautofill.creditCards.available", false); // [FF57+]
 user_pref("extensions.formautofill.creditCards.enabled", false); // [FF56+]
 user_pref("extensions.formautofill.heuristics.enabled", false); // [FF55+]
-/* 0810: disable coloring of visited links
+/* 0820: disable coloring of visited links
  * Bulk rapid history sniffing was mitigated in 2010 [1][2]. Slower and more expensive
  * redraw timing attacks were largely mitigated in FF77+ [3]. Using RFP (4501) further hampers timing
  * attacks. Don't forget clearing history on close (2803). However, social engineering [2#limits][4][5]
@@ -484,13 +483,14 @@ user_pref("security.tls.enable_0rtt_data", false);
    [1] https://scotthelme.co.uk/revocation-is-broken/
    [2] https://blog.mozilla.org/security/2013/07/29/ocsp-stapling-in-firefox/
 ***/
-/* 1211: control when to use OCSP fetching (to confirm current validity of certificates)
+/* 1211: enforce OCSP fetching to confirm current validity of certificates
  * 0=disabled, 1=enabled (default), 2=enabled for EV certificates only
  * OCSP (non-stapled) leaks information about the sites you visit to the CA (cert authority)
  * It's a trade-off between security (checking) and privacy (leaking info to the CA)
  * [NOTE] This pref only controls OCSP fetching and does not affect OCSP stapling
+ * [SETTING] Privacy & Security>Security>Certificates>Query OCSP responder servers...
  * [1] https://en.wikipedia.org/wiki/Ocsp ***/
-user_pref("security.OCSP.enabled", 1);
+user_pref("security.OCSP.enabled", 1); // [DEFAULT: 1]
 /* 1212: set OCSP fetch failures (non-stapled, see 1211) to hard-fail [SETUP-WEB]
  * When a CA cannot be reached to validate a cert, Firefox just continues the connection (=soft-fail)
  * Setting this pref to true tells Firefox to instead terminate the connection (=hard-fail)
@@ -516,7 +516,7 @@ user_pref("security.pki.sha1_enforcement_level", 1);
  * [1] https://gitlab.torproject.org/tpo/applications/tor-browser/-/issues/21686 ***/
 user_pref("security.family_safety.mode", 0);
 /* 1223: enable strict pinning
- * PKP (Public Key Pinning) 0=disabled 1=allow user MiTM (such as your antivirus), 2=strict
+ * PKP (Public Key Pinning) 0=disabled, 1=allow user MiTM (such as your antivirus), 2=strict
  * [SETUP-WEB] If you rely on an AV (antivirus) to protect your web browsing
  * by inspecting ALL your web traffic, then leave at current default=1
  * [1] https://gitlab.torproject.org/tpo/applications/tor-browser/-/issues/16206 ***/
@@ -555,7 +555,7 @@ user_pref("dom.security.https_only_mode_send_http_background_request", false);
  * [2] https://bugzilla.mozilla.org/1353705 ***/
 user_pref("security.ssl.treat_unsafe_negotiation_as_broken", true);
 /* 1271: control "Add Security Exception" dialog on SSL warnings
- * 0=do neither 1=pre-populate url 2=pre-populate url + pre-fetch cert (default)
+ * 0=do neither, 1=pre-populate url, 2=pre-populate url + pre-fetch cert (default)
  * [1] https://github.com/pyllyukko/user.js/issues/210 ***/
 user_pref("browser.ssl_override_behavior", 1);
 /* 1272: display advanced information on Insecure Connection warning pages
@@ -712,28 +712,6 @@ user_pref("dom.disable_open_during_load", true);
 /* 2404: limit events that can cause a popup [SETUP-WEB] ***/
 user_pref("dom.popup_allowed_events", "click dblclick mousedown pointerdown");
 
-/*** [SECTION 2500]: FINGERPRINTING ***/
-user_pref("_user.js.parrot", "2500 syntax error: the parrot's shuffled off 'is mortal coil!");
-/* 2501: enforce no system colors
- * [SETTING] General>Language and Appearance>Fonts and Colors>Colors>Use system colors ***/
-user_pref("browser.display.use_system_colors", false); // [DEFAULT: false]
-/* 2502: enforce non-native widget theme
- * Security: removes/reduces system API calls, e.g. win32k API [1]
- * Fingerprinting: provides a uniform look and feel across platforms [2]
- * [1] https://bugzilla.mozilla.org/1381938
- * [2] https://bugzilla.mozilla.org/1411425 ***/
-user_pref("widget.non-native-theme.enabled", true); // [DEFAULT: true FF89+]
-/* 2503: open links targeting new windows in a new tab instead
- * Stops malicious window sizes and some screen resolution leaks.
- * You can still right-click a link and open in a new window
- * [TEST] https://arkenfox.github.io/TZP/tzp.html#screen
- * [1] https://gitlab.torproject.org/tpo/applications/tor-browser/-/issues/9881 ***/
-user_pref("browser.link.open_newwindow", 3); // 1=most recent window or tab 2=new window, 3=new tab
-user_pref("browser.link.open_newwindow.restriction", 0);
-/* 2504: disable WebGL (Web Graphics Library)
- * [SETUP-WEB] If you need it then enable it. RFP still randomizes canvas for naive scripts ***/
-user_pref("webgl.disabled", true);
-
 /*** [SECTION 2600]: MISCELLANEOUS ***/
 user_pref("_user.js.parrot", "2600 syntax error: the parrot's run down the curtain!");
 /* 2601: prevent accessibility services from accessing your browser [RESTART]
@@ -808,7 +786,7 @@ user_pref("browser.download.manager.addToRecentDocs", false);
  * [SETUP-CHROME] This will break extensions, language packs, themes and any other
  * XPI files which are installed outside of profile and application directories
  * [1] https://mike.kaply.com/2012/02/21/understanding-add-on-scopes/
- * [1] archived: https://archive.is/DYjAM ***/
+ * [1] https://archive.is/DYjAM (archived) ***/
 user_pref("extensions.enabledScopes", 5); // [HIDDEN PREF]
 user_pref("extensions.autoDisableScopes", 15); // [DEFAULT: 15]
 /* 2662: disable webextension restrictions on certain mozilla domains (you also need 4503) [FF60+]
@@ -1061,6 +1039,29 @@ user_pref("privacy.resistFingerprinting.letterboxing", true); // [HIDDEN PREF]
  * [1] https://bugzilla.mozilla.org/1635603 ***/
    // user_pref("privacy.resistFingerprinting.exemptedDomains", "*.example.invalid");
    // user_pref("privacy.resistFingerprinting.testGranularityMask", 0);
+/* 4510: enforce no system colors
+ * [SETTING] General>Language and Appearance>Fonts and Colors>Colors>Use system colors ***/
+user_pref("browser.display.use_system_colors", false); // [DEFAULT: false]
+/* 4511: enforce non-native widget theme
+ * Security: removes/reduces system API calls, e.g. win32k API [1]
+ * Fingerprinting: provides a uniform look and feel across platforms [2]
+ * [1] https://bugzilla.mozilla.org/1381938
+ * [2] https://bugzilla.mozilla.org/1411425 ***/
+user_pref("widget.non-native-theme.enabled", true); // [DEFAULT: true]
+/* 4512: enforce links targeting new windows to open in a new tab instead
+ * 1=most recent window or tab, 2=new window, 3=new tab
+ * Stops malicious window sizes and some screen resolution leaks.
+ * You can still right-click a link and open in a new window
+ * [SETTING] General>Tabs>Open links in tabs instead of new windows
+ * [TEST] https://arkenfox.github.io/TZP/tzp.html#screen
+ * [1] https://gitlab.torproject.org/tpo/applications/tor-browser/-/issues/9881 ***/
+user_pref("browser.link.open_newwindow", 3); // [DEFAULT: 3]
+/* 4513: set all open window methods to abide by "browser.link.open_newwindow" (4512)
+ * [1] https://searchfox.org/mozilla-central/source/dom/tests/browser/browser_test_new_window_from_content.js ***/
+user_pref("browser.link.open_newwindow.restriction", 0); // [DEFAULT: 0]
+/* 4520: disable WebGL (Web Graphics Library)
+ * [SETUP-WEB] If you need it then enable it. RFP still randomizes canvas for naive scripts ***/
+user_pref("webgl.disabled", true);
 
 /*** [SECTION 5000]: OPTIONAL OPSEC
    Disk avoidance, application data isolation, eyeballs...
@@ -1265,6 +1266,10 @@ user_pref("gfx.downloadable_fonts.fallback_delay", -1);
  * [WHY] Fingerprintable. Breakage. Cut/copy/paste require user
  * interaction, and paste is limited to focused editable fields ***/
 user_pref("dom.event.clipboardevents.enabled", false);
+/* 7014: disable System Add-on updates
+ * [WHY] It can compromise security. System addons ship with prefs, use those ***/
+   // user_pref("extensions.systemAddon.update.enabled", false); // [FF62+]
+   // user_pref("extensions.systemAddon.update.url", ""); // [FF44+]
 
 /*** [SECTION 8000]: DON'T BOTHER: NON-RFP
    [WHY] They are insufficient to help anti-fingerprinting and do more harm than good
@@ -1671,7 +1676,7 @@ user_pref("mail.openpgp.allow_external_gnupg", true);  // [HIDDEN PREF]
    Documentation denoted as [-]. Items deprecated in FF78 or earlier have been archived at [1]
    [1] https://github.com/arkenfox/user.js/issues/123
 ***/
-user_pref("_user.js.parrot", "9999 syntax error: the parrot's deprecated!");
+ user_pref("_user.js.parrot", "9999 syntax error: the parrot's shuffled off 'is mortal coil!");
 /* ESR78.x still uses all the following prefs
 // [NOTE] replace the * with a slash in the line above to re-enable them
 // FF79

--- a/user.js
+++ b/user.js
@@ -1490,6 +1490,7 @@ user_pref("mail.inline_attachments", false);
  * [2] http://forums.mozillazine.org/viewtopic.php?f=39&t=2949521 */
 user_pref("mail.compose.big_attachments.notify", true); // [DEFAULT: true]
 /* 9219: Set big attachment size to warn at */
+user_pref("mail.compose.big_attachments.threshold_kb", 9220); // [DEFAULT: 5120]
    // user_pref("mailnews.message_warning_size", 20971520); // [DEFAULT: 20971520]
 
 /** VIEW ***/

--- a/user.js
+++ b/user.js
@@ -1165,16 +1165,20 @@ user_pref("privacy.window.name.update.enabled", true); // [DEFAULT: true FF86+]
    // user_pref("webgl.enable-webgl2", "");
    // user_pref("webgl.min_capability_mode", "");
 
-/*** [SECTION 7000]: DON'T BOTHER ***/
+/*** [SECTION 7000]: DON'T BOTHER
+   Thunderbird-User.JS maintainer here :
+        Actually we do, TB is an e-mail client, not a (bloated) browser.
+        Thus some of below preferences have been set, despite upstream (Arkenfox) warnings.
+***/
 user_pref("_user.js.parrot", "7000 syntax error: the parrot's pushing up daisies!");
 /* 7001: disable APIs
  * Location-Aware Browsing, Full Screen, offline cache (appCache), Virtual Reality
  * [WHY] The API state is easily fingerprintable. Geo and VR are behind prompts (7002).
  * appCache storage capability was removed in FF90. Full screen requires user interaction ***/
-   // user_pref("geo.enabled", false);
-   // user_pref("full-screen-api.enabled", false);
-   // user_pref("browser.cache.offline.enable", false);
-   // user_pref("dom.vr.enabled", false);
+user_pref("geo.enabled", false);
+user_pref("full-screen-api.enabled", false);
+user_pref("browser.cache.offline.enable", false);
+user_pref("dom.vr.enabled", false);
 /* 7002: set default permissions
  * Location, Camera, Microphone, Notifications [FF58+] Virtual Reality [FF73+]
  * 0=always ask (default), 1=allow, 2=block
@@ -1182,11 +1186,11 @@ user_pref("_user.js.parrot", "7000 syntax error: the parrot's pushing up daisies
  * exceptions as allow/block for frequently visited/annoying sites: i.e. not global
  * [SETTING] to add site exceptions: Ctrl+I>Permissions>
  * [SETTING] to manage site exceptions: Options>Privacy & Security>Permissions>Settings ***/
-   // user_pref("permissions.default.geo", 0);
-   // user_pref("permissions.default.camera", 0);
-   // user_pref("permissions.default.microphone", 0);
-   // user_pref("permissions.default.desktop-notification", 0);
-   // user_pref("permissions.default.xr", 0); // Virtual Reality
+user_pref("permissions.default.geo", 0);
+user_pref("permissions.default.camera", 0);
+user_pref("permissions.default.microphone", 0);
+user_pref("permissions.default.desktop-notification", 0);
+user_pref("permissions.default.xr", 0); // Virtual Reality
 /* 7003: disable non-modern cipher suites [1]
  * [WHY] Passive fingerprinting. Minimal/non-existent threat of downgrade attacks
  * [1] https://browserleaks.com/ssl ***/
@@ -1213,13 +1217,13 @@ user_pref("_user.js.parrot", "7000 syntax error: the parrot's pushing up daisies
    // user_pref("network.http.referer.hideOnionSource", true); // 1305144
 /* 7007: referers
  * [WHY] Only cross-origin referers (1600s) need control ***/
-   // user_pref("network.http.sendRefererHeader", 2);
-   // user_pref("network.http.referer.trimmingPolicy", 0);
+user_pref("network.http.sendRefererHeader", 0);
+user_pref("network.http.referer.trimmingPolicy", 0);
 /* 7008: set the default Referrer Policy [FF59+]
  * 0=no-referer, 1=same-origin, 2=strict-origin-when-cross-origin, 3=no-referrer-when-downgrade
  * [WHY] Defaults are fine. They can be overridden by a site-controlled Referrer Policy ***/
-   // user_pref("network.http.referer.defaultPolicy", 2); // [DEFAULT: 2 FF87+]
-   // user_pref("network.http.referer.defaultPolicy.pbmode", 2); // [DEFAULT: 2]
+user_pref("network.http.referer.defaultPolicy", 0); // [DEFAULT: 2 FF87+]
+user_pref("network.http.referer.defaultPolicy.pbmode", 0); // [DEFAULT: 2]
 /* 7009: disable HTTP2
  * [WHY] Passive fingerprinting. ~50% of sites use HTTP2 [1]
  * [1] https://w3techs.com/technologies/details/ce-http2/all/all ***/
@@ -1229,21 +1233,21 @@ user_pref("_user.js.parrot", "7000 syntax error: the parrot's pushing up daisies
    // user_pref("network.http.spdy.websockets", false); // [FF65+]
 /* 7010: disable HTTP Alternative Services [FF37+]
  * [WHY] Already isolated by network partitioning (FF85+) or FPI ***/
-   // user_pref("network.http.altsvc.enabled", false);
-   // user_pref("network.http.altsvc.oe", false);
+user_pref("network.http.altsvc.enabled", false);
+user_pref("network.http.altsvc.oe", false);
 /* 7011: disable website control over browser right-click context menu
  * [WHY] Just use Shift-Right-Click ***/
-   // user_pref("dom.event.contextmenu.enabled", false);
+user_pref("dom.event.contextmenu.enabled", false);
 /* 7012: disable icon fonts (glyphs) and local fallback rendering
  * [WHY] Breakage, font fallback is equivalency, also RFP
  * [1] https://bugzilla.mozilla.org/789788
  * [2] https://gitlab.torproject.org/legacy/trac/-/issues/8455 ***/
-   // user_pref("gfx.downloadable_fonts.enabled", false); // [FF41+]
-   // user_pref("gfx.downloadable_fonts.fallback_delay", -1);
+user_pref("gfx.downloadable_fonts.enabled", false); // [FF41+]
+user_pref("gfx.downloadable_fonts.fallback_delay", -1);
 /* 7013: disable Clipboard API
  * [WHY] Fingerprintable. Breakage. Cut/copy/paste require user
  * interaction, and paste is limited to focused editable fields ***/
-   // user_pref("dom.event.clipboardevents.enabled", false);
+user_pref("dom.event.clipboardevents.enabled", false);
 
 /*** [SECTION 8000]: DON'T BOTHER: NON-RFP
    [WHY] They are insufficient to help anti-fingerprinting and do more harm than good

--- a/user.js
+++ b/user.js
@@ -180,9 +180,9 @@ user_pref("toolkit.telemetry.bhrPing.enabled", false); // [FF57+] Background Han
 user_pref("toolkit.telemetry.firstShutdownPing.enabled", false); // [FF57+]
 /* 0333: disable Telemetry Coverage
   * [1] https://blog.mozilla.org/data/2018/08/20/effectively-measuring-search-in-firefox/ ***/
- user_pref("toolkit.telemetry.coverage.opt-out", true); // [HIDDEN PREF]
- user_pref("toolkit.coverage.opt-out", true); // [FF64+] [HIDDEN PREF]
- user_pref("toolkit.coverage.endpoint.base", "");
+user_pref("toolkit.telemetry.coverage.opt-out", true); // [HIDDEN PREF]
+user_pref("toolkit.coverage.opt-out", true); // [FF64+] [HIDDEN PREF]
+user_pref("toolkit.coverage.endpoint.base", "");
 /* 0334: disable PingCentre telemetry (used in several System Add-ons) [FF57+]
  * Defense-in-depth: currently covered by 0331 ***/
 user_pref("browser.ping-centre.telemetry", false);
@@ -1676,7 +1676,7 @@ user_pref("mail.openpgp.allow_external_gnupg", true);  // [HIDDEN PREF]
    Documentation denoted as [-]. Items deprecated in FF78 or earlier have been archived at [1]
    [1] https://github.com/arkenfox/user.js/issues/123
 ***/
- user_pref("_user.js.parrot", "9999 syntax error: the parrot's shuffled off 'is mortal coil!");
+user_pref("_user.js.parrot", "9999 syntax error: the parrot's shuffled off 'is mortal coil!");
 /* ESR78.x still uses all the following prefs
 // [NOTE] replace the * with a slash in the line above to re-enable them
 // FF79

--- a/user.js
+++ b/user.js
@@ -760,9 +760,6 @@ user_pref("devtools.debugger.remote-enabled", false); // [DEFAULT: false]
 /* 2611: disable middle mouse click opening links from clipboard
  * [1] https://gitlab.torproject.org/tpo/applications/tor-browser/-/issues/10089 ***/
 user_pref("middlemouse.contentLoadURL", false);
-/* 2615: disable websites overriding Thunderbird's keyboard shortcuts [FF58+]
- * 0 (default) or 1=allow, 2=block ***/
-user_pref("permissions.default.shortcuts", 2);
 /* 2616: remove special permissions for certain mozilla domains [FF35+]
  * [1] resource://app/defaults/permissions ***/
 user_pref("permissions.manager.defaultsUrl", "");
@@ -1210,18 +1207,6 @@ user_pref("geo.enabled", false);
 user_pref("full-screen-api.enabled", false);
 user_pref("browser.cache.offline.enable", false);
 user_pref("dom.vr.enabled", false);
-/* 7002: set default permissions
- * Location, Camera, Microphone, Notifications [FF58+] Virtual Reality [FF73+]
- * 0=always ask (default), 1=allow, 2=block
- * [WHY] These are fingerprintable via Permissions API, except VR. Just add site
- * exceptions as allow/block for frequently visited/annoying sites: i.e. not global
- * [SETTING] to add site exceptions: Ctrl+I>Permissions>
- * [SETTING] to manage site exceptions: Options>Privacy & Security>Permissions>Settings ***/
-user_pref("permissions.default.geo", 0);
-user_pref("permissions.default.camera", 0);
-user_pref("permissions.default.microphone", 0);
-user_pref("permissions.default.desktop-notification", 0);
-user_pref("permissions.default.xr", 0); // Virtual Reality
 /* 7003: disable non-modern cipher suites [1]
  * [WHY] Passive fingerprinting. Minimal/non-existent threat of downgrade attacks
  * [1] https://browserleaks.com/ssl ***/

--- a/user.js
+++ b/user.js
@@ -575,74 +575,43 @@ user_pref("gfx.font_rendering.opentype_svg.enabled", false);
 user_pref("layout.css.font-visibility.level", 1);
 
 /*** [SECTION 1600]: HEADERS / REFERERS
-     Only *cross domain* referers need controlling: leave 1601, 1602, 1605 and 1606 alone
-     ---
-            harden it a bit: set XOriginPolicy (1603) to 1 (as per the settings below)
-       harden it a bit more: set XOriginPolicy (1603) to 2 (and optionally 1604 to 1 or 2), expect breakage
-     ---
-     If you want any REAL control over referers and breakage, then use an extension. Either:
-              uMatrix: limited by scope, all requests are spoofed or not-spoofed
-       Smart Referrer: granular with source<->destination, whitelists
-     ---
-
-                    full URI: https://example.com:8888/foo/bar.html?id=1234
-       scheme+host+port+path: https://example.com:8888/foo/bar.html
-            scheme+host+port: https://example.com:8888
-     ---
-     #Required reading [#] https://feeding.cloud.geek.nz/posts/tweaking-referrer-for-privacy-in-firefox/
+   Expect some breakage e.g. banks: use an extension if you need precise control
+                  full URI: https://example.com:8888/foo/bar.html?id=1234
+     scheme+host+port+path: https://example.com:8888/foo/bar.html
+          scheme+host+port: https://example.com:8888
+   [1] https://feeding.cloud.geek.nz/posts/tweaking-referrer-for-privacy-in-firefox/
 ***/
 user_pref("_user.js.parrot", "1600 syntax error: the parrot rests in peace!");
-/* 1601: ALL: control when images/links send a referer
- * 0=never, 1=send only when links are clicked, 2=for links and images (default) ***/
-user_pref("network.http.sendRefererHeader", 0); // [DEFAULT: 2]
-/* 1602: ALL: control the amount of information to send
- * 0=send full URI (default), 1=scheme+host+port+path, 2=scheme+host+port ***/
-   // user_pref("network.http.referer.trimmingPolicy", 0); // [DEFAULT: 0]
-/* 1603: CROSS ORIGIN: control when to send a referer
+/* 1601: control when to send a cross-origin referer
  * 0=always (default), 1=only if base domains match, 2=only if hosts match
- * [SETUP-WEB] Known to cause issues with older modems/routers and some sites e.g vimeo, icloud ***/
+ * [SETUP-WEB] Known to cause issues with older modems/routers and some sites e.g vimeo, icloud, instagram ***/
 user_pref("network.http.referer.XOriginPolicy", 2);
-/* 1604: CROSS ORIGIN: control the amount of information to send [FF52+]
+/* 1602: control the amount of cross-origin information to send [FF52+]
  * 0=send full URI (default), 1=scheme+host+port+path, 2=scheme+host+port ***/
-user_pref("network.http.referer.XOriginTrimmingPolicy", 0); // [DEFAULT: 0]
-/* 1605: ALL: disable spoofing a referer
- * [WARNING] Do not set this to true, as spoofing effectively disables the anti-CSRF
- * (Cross-Site Request Forgery) protections that some sites may rely on ***/
-   // user_pref("network.http.referer.spoofSource", false); // [DEFAULT: false]
-/* 1606: ALL: set the default Referrer Policy [FF59+]
- * 0=no-referer, 1=same-origin, 2=strict-origin-when-cross-origin, 3=no-referrer-when-downgrade
- * [NOTE] This is only a default, it can be overridden by a site-controlled Referrer Policy
- * [1] https://www.w3.org/TR/referrer-policy/
- * [2] https://developer.mozilla.org/docs/Web/HTTP/Headers/Referrer-Policy
- * [3] https://blog.mozilla.org/security/2018/01/31/preventing-data-leaks-by-stripping-path-information-in-http-referrers/ ***/
-user_pref("network.http.referer.defaultPolicy", 0); // [DEFAULT: 3]
-user_pref("network.http.referer.defaultPolicy.pbmode", 0); // [DEFAULT: 2]
-/* 1610: ALL: enable the DNT (Do Not Track) HTTP header
- * [NOTE] DNT is enforced with Enhanced Tracking Protection regardless of this pref
+user_pref("network.http.referer.XOriginTrimmingPolicy", 2);
+/* 1603: enable the DNT (Do Not Track) HTTP header
+ * [NOTE] DNT is enforced with Enhanced Tracking Protection (2710)
  * [SETTING] Privacy & Security>Enhanced Tracking Protection>Send websites a "Do Not Track" signal... ***/
 user_pref("privacy.donottrackheader.enabled", true);
 
-/*** [SECTION 1800]: PLUGINS ***/
-user_pref("_user.js.parrot", "1800 syntax error: the parrot's pushing up daisies!");
-/* 1803: disable Flash plugin
- * 0=deactivated, 1=ask, 2=enabled
- * ESR52.x is the last branch to *fully* support NPAPI, FF52+ stable only supports Flash
- * [NOTE] You can still override individual sites via site permissions ***/
-user_pref("plugin.state.flash", 0);
-/* 1820: disable GMP (Gecko Media Plugins)
- * [1] https://wiki.mozilla.org/GeckoMediaPlugins ***/
-   // user_pref("media.gmp-provider.enabled", false);
-/* 1825: disable widevine CDM (Content Decryption Module)
- * [SETUP-WEB] if you *need* CDM, e.g. Netflix, Amazon Prime, Hulu, whatever ***/
-user_pref("media.gmp-widevinecdm.visible", false);
-user_pref("media.gmp-widevinecdm.enabled", false);
-/* 1830: disable all DRM content (EME: Encryption Media Extension)
- * [SETUP-WEB] if you *need* EME, e.g. Netflix, Amazon Prime, Hulu, whatever
- * [SETTING] General>DRM Content>Play DRM-controlled content
- * [1] https://www.eff.org/deeplinks/2017/10/drms-dead-canary-how-we-just-lost-web-what-we-learned-it-and-what-we-need-do-next ***/
-user_pref("media.eme.enabled", false);
+/*** [SECTION 1700]: CONTAINERS
+   Check out Temporary Containers [2], read the article [3], and visit the wiki/repo [4]
+   [1] https://wiki.mozilla.org/Security/Contextual_Identity_Project/Containers
+   [2] https://addons.mozilla.org/firefox/addon/temporary-containers/
+   [3] https://medium.com/@stoically/enhance-your-privacy-in-firefox-with-temporary-containers-33925cd6cd21
+   [4] https://github.com/stoically/temporary-containers/wiki
+***/
+user_pref("_user.js.parrot", "1700 syntax error: the parrot's bit the dust!");
+/* 1701: enable Container Tabs and its UI setting [FF50+]
+ * [SETTING] General>Tabs>Enable Container Tabs ***/
+user_pref("privacy.userContext.enabled", true);
+user_pref("privacy.userContext.ui.enabled", true);
+/* 1702: set behaviour on "+ Tab" button to display container menu on left click [FF74+]
+ * [NOTE] The menu is always shown on long press and right click
+ * [SETTING] General>Tabs>Enable Container Tabs>Settings>Select a container for each new tab ***/
+   // user_pref("privacy.userContext.newTabContainerOnLeftClick.enabled", true);
 
-/*** [SECTION 2000]: MEDIA / CAMERA / MIC ***/
+/*** [SECTION 2000]: PLUGINS / MEDIA / WEBRTC ***/
 user_pref("_user.js.parrot", "2000 syntax error: the parrot's snuffed it!");
 /* 2001: disable WebRTC (Web Real-Time Communication)
  * [SETUP-WEB] WebRTC can leak your IP address from behind your VPN, but if this is not
@@ -650,7 +619,7 @@ user_pref("_user.js.parrot", "2000 syntax error: the parrot's snuffed it!");
  * [1] https://www.privacytools.io/#webrtc ***/
 user_pref("media.peerconnection.enabled", false);
 /* 2002: limit WebRTC IP leaks if using WebRTC
- * In FF70+ these settings match Mode 4 (Mode 3 in older versions) (see [3])
+ * In FF70+ these settings match Mode 4 (Mode 3 in older versions) [3]
  * [TEST] https://browserleaks.com/webrtc
  * [1] https://bugzilla.mozilla.org/buglist.cgi?bug_id=1189041,1297416,1452713
  * [2] https://wiki.mozilla.org/Media/WebRTC/Privacy
@@ -658,347 +627,220 @@ user_pref("media.peerconnection.enabled", false);
 user_pref("media.peerconnection.ice.default_address_only", true);
 user_pref("media.peerconnection.ice.no_host", true); // [FF51+]
 user_pref("media.peerconnection.ice.proxy_only_if_behind_proxy", true); // [FF70+]
-/* 2010: disable WebGL (Web Graphics Library)
- * [SETUP-WEB] When disabled, may break some websites. When enabled, provides high entropy,
- * especially with readPixels(). Some of the other entropy is lessened with RFP (see 4501)
- * [1] https://www.contextis.com/resources/blog/webgl-new-dimension-browser-exploitation/
- * [2] https://security.stackexchange.com/questions/13799/is-webgl-a-security-concern ***/
-user_pref("webgl.disabled", true);
-user_pref("webgl.enable-webgl2", false);
-/* 2012: limit WebGL ***/
-user_pref("webgl.min_capability_mode", true);
-user_pref("webgl.disable-fail-if-major-performance-caveat", true);
-/* 2022: disable screensharing ***/
-user_pref("media.getusermedia.screensharing.enabled", false);
-user_pref("media.getusermedia.browser.enabled", false);
-user_pref("media.getusermedia.audiocapture.enabled", false);
+/* 2020: disable GMP (Gecko Media Plugins)
+ * [1] https://wiki.mozilla.org/GeckoMediaPlugins ***/
+user_pref("media.gmp-provider.enabled", false);
+/* 2021: disable widevine CDM (Content Decryption Module)
+ * [NOTE] This is covered by the EME master switch (2022) ***/
+user_pref("media.gmp-widevinecdm.enabled", false);
+/* 2022: disable all DRM content (EME: Encryption Media Extension)
+ * [SETUP-WEB] e.g. Netflix, Amazon Prime, Hulu, HBO, Disney+, Showtime, Starz, DirectTV
+ * [SETTING] General>DRM Content>Play DRM-controlled content
+ * [TEST] https://bitmovin.com/demos/drm
+ * [1] https://www.eff.org/deeplinks/2017/10/drms-dead-canary-how-we-just-lost-web-what-we-learned-it-and-what-we-need-do-next ***/
+user_pref("media.eme.enabled", false);
 /* 2030: disable autoplay of HTML5 media [FF63+]
- * 0=Allow all, 1=Block non-muted media (default in FF67+), 2=Prompt (removed in FF66), 5=Block all (FF69+)
+ * 0=Allow all, 1=Block non-muted media (default), 5=Block all
  * [NOTE] You can set exceptions under site permissions
-* [SETTING] Privacy & Security>Permissions>Autoplay>Settings>Default for all websites ***/
-   // user_pref("media.autoplay.default", 5);
+ * [SETTING] Privacy & Security>Permissions>Autoplay>Settings>Default for all websites ***/
+user_pref("media.autoplay.default", 5);
 /* 2031: disable autoplay of HTML5 media if you interacted with the site [FF78+]
  * 0=sticky (default), 1=transient, 2=user
- * [NOTE] If you have trouble with some video sites, then add an exception (see 2030)
- * [1] https://html.spec.whatwg.org/multipage/interaction.html#sticky-activation ***/
+ * Firefox's Autoplay Policy Documentation [PDF] is linked below via SUMO
+ * [NOTE] If you have trouble with some video sites, then add an exception (2030)
+ * [1] https://support.mozilla.org/questions/1293231 ***/
 user_pref("media.autoplay.blocking_policy", 2);
 
-/*** [SECTION 2200]: WINDOW MEDDLING & LEAKS / POPUPS ***/
-user_pref("_user.js.parrot", "2200 syntax error: the parrot's 'istory!");
-/* 2201: prevent websites from disabling new window features ***/
-user_pref("dom.disable_window_open_feature.close", true);
-user_pref("dom.disable_window_open_feature.location", true); // [DEFAULT: true]
-user_pref("dom.disable_window_open_feature.menubar", true);
-user_pref("dom.disable_window_open_feature.minimizable", true);
-user_pref("dom.disable_window_open_feature.personalbar", true); // bookmarks toolbar
-user_pref("dom.disable_window_open_feature.resizable", true); // [DEFAULT: true]
-user_pref("dom.disable_window_open_feature.status", true); // [DEFAULT: true]
-user_pref("dom.disable_window_open_feature.titlebar", true);
-user_pref("dom.disable_window_open_feature.toolbar", true);
-/* 2202: prevent scripts from moving and resizing open windows ***/
-user_pref("dom.disable_window_move_resize", true);
-/* 2203: open links targeting new windows in a new tab instead
- * This stops malicious window sizes and some screen resolution leaks.
- * You can still right-click a link and open in a new window.
- * [NOTE] Unlike arkenfox/user.js, we explicitly set them
- * [TEST] https://arkenfox.github.io/TZP/tzp.html#screen
- * [1] https://gitlab.torproject.org/tpo/applications/tor-browser/-/issues/9881 ***/
-user_pref("browser.link.open_newwindow", 3);
-user_pref("browser.link.open_newwindow.restriction", 0);
-/* 2204: disable Fullscreen API (requires user interaction) to prevent screen-resolution leaks
- * [NOTE] You can still manually toggle the browser's fullscreen state (F11),
- * but this pref will disable embedded video/game fullscreen controls, e.g. youtube
- * [TEST] https://arkenfox.github.io/TZP/tzp.html#screen ***/
-   // user_pref("full-screen-api.enabled", false);  // [DEFAULT: false]
-/* 2210: block popup windows
- * [SETTING] Privacy & Security>Permissions>Block pop-up windows ***/
-user_pref("dom.disable_open_during_load", true);
-/* 2212: limit events that can cause a popup [SETUP-WEB]
- * default is "change click dblclick auxclick mouseup pointerup notificationclick reset submit touchend contextmenu" ***/
-user_pref("dom.popup_allowed_events", "click dblclick");
-
 /*** [SECTION 2300]: WEB WORKERS
-     A worker is a JS "background task" running in a global context, i.e. it is different from
-     the current window. Workers can spawn new workers (must be the same origin & scheme),
-     including service and shared workers. Shared workers can be utilized by multiple scripts and
-     communicate between browsing contexts (windows/tabs/iframes) and can even control your cache.
-     [NOTE] uMatrix 1.2.0+ allows a per-scope control for workers (2301-deprecated) and service workers (2302)
-              #Required reading [#] https://github.com/gorhill/uMatrix/releases/tag/1.2.0
-     [1]    Web Workers: https://developer.mozilla.org/docs/Web/API/Web_Workers_API
-     [2]         Worker: https://developer.mozilla.org/docs/Web/API/Worker
-     [3] Service Worker: https://developer.mozilla.org/docs/Web/API/Service_Worker_API
-     [4]   SharedWorker: https://developer.mozilla.org/docs/Web/API/SharedWorker
-     [5]   ChromeWorker: https://developer.mozilla.org/docs/Web/API/ChromeWorker
-     [6]  Notifications: https://support.mozilla.org/questions/1165867#answer-981820
+   A worker is a JS "background task" running in a global context, i.e. it is different from
+   the current window. Workers can spawn new workers (must be the same origin & scheme),
+   including service and shared workers. Shared workers can be utilized by multiple scripts and
+   communicate between browsing contexts (windows/tabs/iframes) and can even control your cache.
+
+   [1]    Web Workers: https://developer.mozilla.org/docs/Web/API/Web_Workers_API
+   [2]         Worker: https://developer.mozilla.org/docs/Web/API/Worker
+   [3] Service Worker: https://developer.mozilla.org/docs/Web/API/Service_Worker_API
+   [4]   SharedWorker: https://developer.mozilla.org/docs/Web/API/SharedWorker
+   [5]   ChromeWorker: https://developer.mozilla.org/docs/Web/API/ChromeWorker
+   [6]  Notifications: https://support.mozilla.org/questions/1165867#answer-981820
 ***/
 user_pref("_user.js.parrot", "2300 syntax error: the parrot's off the twig!");
 /* 2302: disable service workers [FF32, FF44-compat]
  * Service workers essentially act as proxy servers that sit between web apps, and the
- * browser and network, are event driven, and can control the web page/site it is associated
+ * browser and network, are event driven, and can control the web page/site they are associated
  * with, intercepting and modifying navigation and resource requests, and caching resources.
- * [NOTE] Service worker APIs are hidden (in Firefox) and cannot be used when in PB mode.
- * [NOTE] Service workers only run over HTTPS. Service workers have no DOM access.
+ * [NOTE] Service workers require HTTPS, have no DOM access, and are not supported in PB mode [1]
  * [SETUP-WEB] Disabling service workers will break some sites. This pref is required true for
  * service worker notifications (2304), push notifications (disabled, 2305) and service worker
- * cache (2740). If you enable this pref, then check those settings as well ***/
+ * cache (2740). If you enable this pref, then check those settings as well
+ * [1] https://bugzilla.mozilla.org/show_bug.cgi?id=1320796#c7 ***/
 user_pref("dom.serviceWorkers.enabled", false);
 /* 2304: disable Web Notifications
- * [NOTE] Web Notifications can also use service workers (2302) and are behind a prompt (2306)
- * [NOTE] Unlike arkenfox/user.js, we explicitly disable them as they are enabled by default
+ * [NOTE] Web Notifications can also use service workers (2302) and are behind a prompt (7002)
  * [1] https://developer.mozilla.org/docs/Web/API/Notifications_API ***/
 user_pref("dom.webnotifications.enabled", false); // [FF22+]
 user_pref("dom.webnotifications.serviceworker.enabled", false); // [FF44+]
 /* 2305: disable Push Notifications [FF44+]
  * Push is an API that allows websites to send you (subscribed) messages even when the site
- * isn't loaded, by pushing messages to your userAgentID through Mozilla's Push Server.
+ * isn't loaded, by pushing messages to your userAgentID through Mozilla's Push Server
  * [NOTE] Push requires service workers (2302) to subscribe to and display, and is behind
- * a prompt (2306). Disabling service workers alone doesn't stop Firefox polling the
- * Mozilla Push Server. To remove all subscriptions, reset your userAgentID (in about:config
- * or on start), and you will get a new one within a few seconds.
- * [1] https://support.mozilla.org/en-US/kb/push-notifications-firefox
- * [2] https://developer.mozilla.org/en-US/docs/Web/API/Push_API ***/
+ * a prompt (7002). Disabling service workers alone doesn't stop Thunderbird polling the
+ * Mozilla Push Server. To remove all subscriptions, reset your userAgentID.
+ * [1] https://support.mozilla.org/kb/push-notifications-firefox
+ * [2] https://developer.mozilla.org/docs/Web/API/Push_API ***/
 user_pref("dom.push.enabled", false);
    // user_pref("dom.push.userAgentID", "");
-/* 2306: set a default permission for Notifications (both 2304 and 2305) [FF58+]
- * 0=always ask (default), 1=allow, 2=block
- * [NOTE] Best left at default "always ask", fingerprintable via Permissions API
- * [SETTING] to add site exceptions: Page Info>Permissions>Receive Notifications
- * [SETTING] to manage site exceptions: Options>Privacy & Security>Permissions>Notifications>Settings ***/
-   // user_pref("permissions.default.desktop-notification", 2);
 
-/*** [SECTION 2400]: DOM (DOCUMENT OBJECT MODEL) & JAVASCRIPT ***/
+/*** [SECTION 2400]: DOM (DOCUMENT OBJECT MODEL) ***/
 user_pref("_user.js.parrot", "2400 syntax error: the parrot's kicked the bucket!");
-/* 2401: disable website control over browser right-click context menu
- * [NOTE] Shift-Right-Click will always bring up the browser right-click context menu
- * [NOTE] Unlike arkenfox/user.js, we explicitly disable it ***/
-user_pref("dom.event.contextmenu.enabled", false);
-/* 2402: disable website access to clipboard events/content [SETUP-HARDEN]
- * [NOTE] This will break some sites' functionality e.g. Outlook, Twitter, Facebook, Wordpress
- * This applies to onCut/onCopy/onPaste events - i.e. it requires interaction with the website
- * [WARNING] If both 'middlemouse.paste' and 'general.autoScroll' are true (at least one
- * is default false) then enabling this pref can leak clipboard content, see [2]
- * [NOTE] Unlike arkenfox/user.js, we explicitly disable it
- * [1] https://www.ghacks.net/2014/01/08/block-websites-reading-modifying-clipboard-contents-firefox/
- * [2] https://bugzilla.mozilla.org/1528289 */
-user_pref("dom.event.clipboardevents.enabled", false);
-/* 2404: disable clipboard commands (cut/copy) from "non-privileged" content [FF41+]
- * this disables document.execCommand("cut"/"copy") to protect your clipboard
- * [1] https://bugzilla.mozilla.org/1170911 ***/
-user_pref("dom.allow_cut_copy", false);
-/* 2405: disable "Confirm you want to leave" dialog on page close
- * Does not prevent JS leaks of the page close event.
- * [1] https://developer.mozilla.org/docs/Web/Events/beforeunload
- * [2] https://support.mozilla.org/questions/1043508 ***/
+/* 2401: disable "Confirm you want to leave" dialog on page close
+ * Does not prevent JS leaks of the page close event
+ * [1] https://developer.mozilla.org/docs/Web/Events/beforeunload ***/
 user_pref("dom.disable_beforeunload", true);
-/* 2414: disable shaking the screen ***/
-user_pref("dom.vibrator.enabled", false);
-/* 2420: disable asm.js [FF22+] [SETUP-PERF]
- * [1] http://asmjs.org/
- * [2] https://www.mozilla.org/security/advisories/mfsa2015-29/
- * [3] https://www.mozilla.org/security/advisories/mfsa2015-50/
- * [4] https://www.mozilla.org/security/advisories/mfsa2017-01/#CVE-2017-5375
- * [5] https://www.mozilla.org/security/advisories/mfsa2017-05/#CVE-2017-5400
- * [6] https://rh0dev.github.io/blog/2017/the-return-of-the-jit/ ***/
-user_pref("javascript.options.asmjs", false);
-/* 2421: disable Ion and baseline JIT to harden against JS exploits [SETUP-HARDEN]
- * [NOTE] In FF75+, when **both** Ion and JIT are disabled, **and** the new
- * hidden pref is enabled, then Ion can still be used by extensions (1599226)
- * [WARNING] Disabling Ion/JIT can cause some site issues and performance loss
- * [NOTE] Unlike arkenfox/user.js, we explicitly disable them
- * [1] https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-0817 ***/
-user_pref("javascript.options.ion", false);
-user_pref("javascript.options.baselinejit", false);
-/* 2422: disable WebAssembly [FF52+] [SETUP-PERF]
- * [NOTE] In FF71+ this no longer affects extensions (1576254)
- * [1] https://developer.mozilla.org/docs/WebAssembly ***/
-user_pref("javascript.options.wasm", false);
-/* 2426: disable Intersection Observer API [FF55+] [RESTART]
- * [NOTE] Disabling it may break the error console (CTRL+SHIFT+J)
- * [1] https://developer.mozilla.org/docs/Web/API/Intersection_Observer_API
- * [2] https://w3c.github.io/IntersectionObserver/
- * [3] https://bugzilla.mozilla.org/1243846 ***/
-   // user_pref("dom.IntersectionObserver.enabled", false);
-/* 2429: enable (limited but sufficient) window.opener protection [FF65+]
- * Makes rel=noopener implicit for target=_blank in anchor and area elements when no rel attribute is set ***/
-user_pref("dom.targetBlankNoOpener.enabled", true); // [DEFAULT: true FF78+]
+/* 2402: prevent scripts from moving and resizing open windows ***/
+user_pref("dom.disable_window_move_resize", true);
+/* 2403: block popup windows
+ * [SETTING] Privacy & Security>Permissions>Block pop-up windows ***/
+user_pref("dom.disable_open_during_load", true);
+/* 2404: limit events that can cause a popup [SETUP-WEB] ***/
+user_pref("dom.popup_allowed_events", "click dblclick mousedown pointerdown");
 
-/*** [SECTION 2500]: HARDWARE FINGERPRINTING ***/
+/*** [SECTION 2500]: FINGERPRINTING ***/
 user_pref("_user.js.parrot", "2500 syntax error: the parrot's shuffled off 'is mortal coil!");
-/* 2502: disable Battery Status API
- * Initially a Linux issue (high precision readout) that was fixed.
- * However, it is still another metric for fingerprinting, used to raise entropy.
- * e.g. do you have a battery or not, current charging status, charge level, times remaining etc
- * [NOTE] From FF52+ Battery Status API is only available in chrome/privileged code. see [1]
- * [NOTE] Unlike arkenfox/user.js, we explicitly disable it
- * [1] https://bugzilla.mozilla.org/1313580 ***/
-user_pref("dom.battery.enabled", false);
-/* 2505: disable media device enumeration [FF29+]
- * [NOTE] media.peerconnection.enabled should also be set to false (see 2001)
- * [NOTE] Unlike arkenfox/user.js, we explicitly disable it
- * [1] https://wiki.mozilla.org/Media/getUserMedia
- * [2] https://developer.mozilla.org/docs/Web/API/MediaDevices/enumerateDevices ***/
-user_pref("media.navigator.enabled", false);
-/* 2508: disable hardware acceleration to reduce graphics fingerprinting [SETUP-HARDEN]
- * [WARNING] Affects text rendering (fonts will look different), impacts video performance,
- * and parts of Quantum that utilize the GPU will also be affected as they are rolled out
- * [SETTING] General>Performance>Custom>Use hardware acceleration when available
- * [NOTE] Unlike arkenfox/user.js, we explicitly disable it
- * [1] https://wiki.mozilla.org/Platform/GFX/HardwareAcceleration ***/
-user_pref("gfx.direct2d.disabled", true); // [WINDOWS]
-user_pref("layers.acceleration.disabled", true);
-/* 2510: disable Web Audio API [FF51+]
- * [NOTE] Unlike arkenfox/user.js, we explicitly disable it
- * [1] https://bugzilla.mozilla.org/1288359 ***/
-user_pref("dom.webaudio.enabled", false);
-/* 2517: disable Media Capabilities API [FF63+]
- * [WARNING] This *may* affect media performance if disabled, no one is sure
- * [NOTE] Unlike arkenfox/user.js, we explicitly disable it
- * [1] https://github.com/WICG/media-capabilities
- * [2] https://wicg.github.io/media-capabilities/#security-privacy-considerations ***/
-user_pref("media.media-capabilities.enabled", false);
-/* 2520: disable virtual reality devices
- * Optional protection depending on your connected devices
- * [NOTE] Unlike arkenfox/user.js, we explicitly disable them
- * [1] https://developer.mozilla.org/docs/Web/API/WebVR_API ***/
-user_pref("dom.vr.enabled", false);
-/* 2521: set a default permission for Virtual Reality (see 2520) [FF73+]
- * 0=always ask (default), 1=allow, 2=block
- * [SETTING] to add site exceptions: Page Info>Permissions>Access Virtual Reality Devices
- * [SETTING] to manage site exceptions: Options>Privacy & Security>Permissions>Virtual Reality>Settings
- * [NOTE] Unlike arkenfox/user.js, we explicitly disable it ***/
-user_pref("permissions.default.xr", 2);
+/* 2501: enforce no system colors
+ * [SETTING] General>Language and Appearance>Fonts and Colors>Colors>Use system colors ***/
+user_pref("browser.display.use_system_colors", false); // [DEFAULT: false]
+/* 2502: enforce non-native widget theme
+ * Security: removes/reduces system API calls, e.g. win32k API [1]
+ * Fingerprinting: provides a uniform look and feel across platforms [2]
+ * [1] https://bugzilla.mozilla.org/1381938
+ * [2] https://bugzilla.mozilla.org/1411425 ***/
+user_pref("widget.non-native-theme.enabled", true); // [DEFAULT: true FF89+]
+/* 2503: open links targeting new windows in a new tab instead
+ * Stops malicious window sizes and some screen resolution leaks.
+ * You can still right-click a link and open in a new window
+ * [TEST] https://arkenfox.github.io/TZP/tzp.html#screen
+ * [1] https://gitlab.torproject.org/tpo/applications/tor-browser/-/issues/9881 ***/
+user_pref("browser.link.open_newwindow", 3); // 1=most recent window or tab 2=new window, 3=new tab
+user_pref("browser.link.open_newwindow.restriction", 0);
+/* 2504: disable WebGL (Web Graphics Library)
+ * [SETUP-WEB] If you need it then enable it. RFP still randomizes canvas for naive scripts ***/
+user_pref("webgl.disabled", true);
 
 /*** [SECTION 2600]: MISCELLANEOUS ***/
 user_pref("_user.js.parrot", "2600 syntax error: the parrot's run down the curtain!");
-/* 2601: prevent accessibility services from accessing your browser [RESTART] [SETUP-FEATURE]
+/* 2601: prevent accessibility services from accessing your browser [RESTART]
  * [SETTING] Privacy & Security>Permissions>Prevent accessibility services from accessing your browser (FF80 or lower)
  * [1] https://support.mozilla.org/kb/accessibility-services ***/
 user_pref("accessibility.force_disabled", 1);
 /* 2602: disable sending additional analytics to web servers
  * [1] https://developer.mozilla.org/docs/Web/API/Navigator/sendBeacon ***/
 user_pref("beacon.enabled", false);
+/* 2603: remove temp files opened with an external application
+ * [1] https://bugzilla.mozilla.org/302433 ***/
+user_pref("browser.helperApps.deleteTempFileOnExit", true);
+/* 2604: disable page thumbnail collection ***/
+user_pref("browser.pagethumbnails.capturing_disabled", true); // [HIDDEN PREF]
+/* 2606: disable UITour backend so there is no chance that a remote page can use it ***/
+user_pref("browser.uitour.enabled", false);
+user_pref("browser.uitour.url", "");
 /* 2607: disable various developer tools in browser context
  * [SETTING] Devtools>Advanced Settings>Enable browser chrome and add-on debugging toolboxes
  * [1] https://github.com/pyllyukko/user.js/issues/179#issuecomment-246468676 ***/
 user_pref("devtools.chrome.enabled", false);
-/* 2608: disable remote debugging
+/* 2608: reset remote debugging to disabled
  * [1] https://gitlab.torproject.org/tpo/applications/tor-browser/-/issues/16222 ***/
 user_pref("devtools.debugger.remote-enabled", false); // [DEFAULT: false]
-/* 2609: disable MathML (Mathematical Markup Language) [FF51+] [SETUP-HARDEN]
- * [NOTE] Unlike arkenfox/user.js, we explicitly disable it
- * [TEST] https://arkenfox.github.io/TZP/tzp.html#misc
- * [1] https://bugzilla.mozilla.org/1173199 ***/
-user_pref("mathml.disabled", true);
-/* 2610: disable in-content SVG (Scalable Vector Graphics) [FF53+]
- * [NOTE] In FF70+ and ESR68.1.0+ this no longer affects extensions (1564208)
- * [WARNING] Expect breakage incl. youtube player controls. Best left for a "hardened" profile.
- * [1] https://bugzilla.mozilla.org/1216893 ***/
-user_pref("svg.disabled", true);
 /* 2611: disable middle mouse click opening links from clipboard
  * [1] https://gitlab.torproject.org/tpo/applications/tor-browser/-/issues/10089 ***/
 user_pref("middlemouse.contentLoadURL", false);
-/* 2614: limit HTTP redirects (this does not control redirects with HTML meta tags or JS)
- * [NOTE] A low setting of 5 or under will probably break some sites (e.g. gmail logins)
- * To control HTML Meta tag and JS redirects, use an extension. Default is 20 ***/
-user_pref("network.http.redirection-limit", 8);
-/* 2619: enforce Punycode for Internationalized Domain Names to eliminate possible spoofing
- * Firefox has *some* protections, but it is better to be safe than sorry
+/* 2615: disable websites overriding Thunderbird's keyboard shortcuts [FF58+]
+ * 0 (default) or 1=allow, 2=block ***/
+user_pref("permissions.default.shortcuts", 2);
+/* 2616: remove special permissions for certain mozilla domains [FF35+]
+ * [1] resource://app/defaults/permissions ***/
+user_pref("permissions.manager.defaultsUrl", "");
+/* 2617: remove webchannel whitelist ***/
+user_pref("webchannel.allowObject.urlWhitelist", "");
+/* 2619: use Punycode in Internationalized Domain Names to eliminate possible spoofing
  * [SETUP-WEB] Might be undesirable for non-latin alphabet users since legitimate IDN's are also punycoded
  * [TEST] https://www.xn--80ak6aa92e.com/ (www.apple.com)
  * [1] https://wiki.mozilla.org/IDN_Display_Algorithm
  * [2] https://en.wikipedia.org/wiki/IDN_homograph_attack
- * [3] CVE-2017-5383: https://www.mozilla.org/security/advisories/mfsa2017-02/
+ * [3] https://cve.mitre.org/cgi-bin/cvekey.cgi?keyword=punycode+firefox
  * [4] https://www.xudongz.com/blog/2017/idn-phishing/ ***/
 user_pref("network.IDN_show_punycode", true);
-/* 2622: enforce no system colors; they can be fingerprinted
- * [SETTING] General>Language and Appearance>Fonts and Colors>Colors>Use system colors ***/
-user_pref("browser.display.use_system_colors", false); // [DEFAULT: false]
-
-/** DOWNLOADS ***/
-/* 2650: discourage downloading to desktop
- * 0=desktop, 1=downloads (default), 2=last used
- * [SETTING] To set your default "downloads": General>Downloads>Save files to ***/
-   // user_pref("browser.download.folderList", 2);
-/* 2651: enforce user interaction for security by always asking where to download
- * [SETUP-CHROME] On Android this blocks longtapping and saving images
- * [SETTING] General>Downloads>Always ask you where to save files ***/
-user_pref("browser.download.useDownloadDir", false);
-/* 2652: disable adding downloads to the system's "recent documents" list ***/
-user_pref("browser.download.manager.addToRecentDocs", false);
-/* 2653: disable hiding mime types (Options>General>Applications) not associated with a plugin ***/
-user_pref("browser.download.hide_plugins_without_extensions", false);
-/* 2654: disable "open with" in download dialog [FF50+] [SETUP-HARDEN]
- * This is very useful to enable when the browser is sandboxed (e.g. via AppArmor)
- * in such a way that it is forbidden to run external applications.
- * [WARNING] This may interfere with some users' workflow or methods
- * [1] https://bugzilla.mozilla.org/1281959 ***/
-   // user_pref("browser.download.forbid_open_with", true);
-
-/** EXTENSIONS ***/
-/* 2660: lock down allowed extension directories
- * [SETUP-CHROME] This will break extensions, language packs, themes and any other
- * XPI files which are installed outside of profile and application directories
- * [1] https://mike.kaply.com/2012/02/21/understanding-add-on-scopes/
- * [1] archived: https://archive.is/DYjAM ***/
-user_pref("extensions.enabledScopes", 1); // [HIDDEN PREF]
-user_pref("extensions.autoDisableScopes", 15); // [DEFAULT: 15]
-/* 2662: disable webextension restrictions on certain mozilla domains (you also need 4503) [FF60+]
- * [1] https://bugzilla.mozilla.org/buglist.cgi?bug_id=1384330,1406795,1415644,1453988 ***/
-   // user_pref("extensions.webextensions.restrictedDomains", "");
-
-/** SECURITY ***/
-/* 2680: enforce CSP (Content Security Policy)
- * [WARNING] CSP is a very important and widespread security feature. Don't disable it!
- * [1] https://developer.mozilla.org/docs/Web/HTTP/CSP ***/
-user_pref("security.csp.enable", true); // [DEFAULT: true]
-/* 2684: enforce a security delay on some confirmation dialogs such as install, open/save
- * [1] https://www.squarefree.com/2004/07/01/race-conditions-in-security-dialogs/ ***/
-user_pref("security.dialog_enable_delay", 700);
+/* 2620: enforce PDFJS, disable PDFJS scripting [SETUP-CHROME]
+ * This setting controls if the option "Display in Thunderbird" is available in the setting below
+ *   and by effect controls whether PDFs are handled in-browser or externally ("Ask" or "Open With")
+ * PROS: pdfjs is lightweight, open source, and more secure/vetted than most
+ *   Exploits are rare (one serious case in seven years), treated seriously and patched quickly.
+ *   It doesn't break "state separation" of browser content (by not sharing with OS, independent apps).
+ *   It maintains disk avoidance and application data isolation. It's convenient. You can still save to disk.
+ * CONS: You may prefer a different pdf reader for security reasons
+ * CAVEAT: JS can still force a pdf to open in-browser by bundling its own code
+ * [SETTING] General>Applications>Portable Document Format (PDF) ***/
+user_pref("pdfjs.disabled", false); // [DEFAULT: false]
+user_pref("pdfjs.enableScripting", false); // [FF86+]
+/* 2621: disable links launching Windows Store on Windows 8/8.1/10 [WINDOWS] ***/
+user_pref("network.protocol-handler.external.ms-windows-store", false);
+/* 2623: disable permissions delegation [FF73+]
+ * Currently applies to cross-origin geolocation, camera, mic and screen-sharing
+ * permissions, and fullscreen requests. Disabling delegation means any prompts
+ * for these will show/use their correct 3rd party origin
+ * [1] https://groups.google.com/forum/#!topic/mozilla.dev.platform/BdFOMAuCGW8/discussion ***/
+user_pref("permissions.delegation.enabled", false);
 
 /*** [SECTION 2700]: PERSISTENT STORAGE
-     Data SET by websites including
-            cookies : profile\cookies.sqlite
-       localStorage : profile\webappsstore.sqlite
-          indexedDB : profile\storage\default
-           appCache : profile\OfflineCache
-     serviceWorkers :
+   Data SET by websites including
+          cookies : profile\cookies.sqlite
+     localStorage : profile\webappsstore.sqlite
+        indexedDB : profile\storage\default
+   serviceWorkers :
 
-     [NOTE] indexedDB and serviceWorkers are not available in Private Browsing Mode
-     [NOTE] Blocking cookies also blocks websites access to: localStorage (incl. sessionStorage),
-     indexedDB, sharedWorker, and serviceWorker (and therefore service worker cache and notifications)
-     If you set a site exception for cookies (either "Allow" or "Allow for Session") then they become
-     accessible to websites except shared/service workers where the cookie setting *must* be "Allow"
+   [NOTE] indexedDB and serviceWorkers are not available in Private Browsing Mode
+   [NOTE] Blocking cookies also blocks websites access to: localStorage (incl. sessionStorage),
+   indexedDB, sharedWorker, and serviceWorker (and therefore service worker cache and notifications)
+   If you set a site exception for cookies (either "Allow" or "Allow for Session") then they become
+   accessible to websites except shared/service workers where the cookie setting must be "Allow"
 ***/
 user_pref("_user.js.parrot", "2700 syntax error: the parrot's joined the bleedin' choir invisible!");
-/* 2701: disable cookies and site-data [SETUP-WEB]
- * 0=Accept cookies and site data, 1=(Block) All third-party cookies, 2=(Block) All cookies,
- * 3=(Block) Cookies from unvisited websites, 4=(Block) Cross-site and social media trackers (FF63+) (default FF69+)
- * [NOTE] You can set exceptions under site permissions or use an extension
- * [NOTE] Unlike arkenfox/user.js, we block **ALL** cookies on purpose
- * [SETTING] Privacy & Security>Privacy>Web Content>Accept cookies from sites ***/
+/* 2701: disable or isolate 3rd-party cookies and site-data [SETUP-WEB]
+ * 0 = Accept cookies and site data
+ * 1 = (Block) All third-party cookies
+ * 2 = (Block) All cookies
+ * 3 = (Block) Cookies from unvisited websites
+ * 4 = (Block) Cross-site tracking cookies (default)
+ * 5 = (Isolate All) Cross-site cookies (TCP: Total Cookie Protection / dFPI: dynamic FPI) [1] (FF86+)
+ * Option 5 with FPI enabled (4001) is ignored and not shown, and option 4 used instead
+ * [NOTE] You can set cookie exceptions under site permissions or use an extension
+ * [NOTE] Enforcing category to custom ensures ETP related prefs are always honored
+ * [SETTING] Privacy & Security>Enhanced Tracking Protection>Custom>Cookies
+ * [1] https://blog.mozilla.org/security/2021/02/23/total-cookie-protection/ ***/
 user_pref("network.cookie.cookieBehavior", 2);
-/* 2702: set third-party cookies (i.e ALL) (if enabled, see 2701) to session-only
-   and (FF58+) set third-party non-secure (i.e HTTP) cookies to session-only
-   [NOTE] .sessionOnly overrides .nonsecureSessionOnly except when .sessionOnly=false and
-   .nonsecureSessionOnly=true. This allows you to keep HTTPS cookies, but session-only HTTP ones
+user_pref("browser.contentblocking.category", "custom");
+/* 2702: set third-party cookies (if enabled, see 2701) to session-only
+ * [NOTE] .sessionOnly overrides .nonsecureSessionOnly except when .sessionOnly=false and
+ * .nonsecureSessionOnly=true. This allows you to keep HTTPS cookies, but session-only HTTP ones
  * [1] https://feeding.cloud.geek.nz/posts/tweaking-cookies-for-privacy-in-firefox/ ***/
 user_pref("network.cookie.thirdparty.sessionOnly", true);
 user_pref("network.cookie.thirdparty.nonsecureSessionOnly", true); // [FF58+]
 /* 2703: delete cookies and site data on close
  * 0=keep until they expire (default), 2=keep until you close Thunderbird
  * [NOTE] The setting below is disabled (but not changed) if you block all cookies (2701 = 2)
- * [NOTE] Unlike arkenfox/user.js, we keep them until Thunderbird exit on purpose
- * [SETTING] Privacy & Security>Privacy>Web Content>Keep until: "I close Thunderbird" ***/
+ * [SETTING] Privacy & Security>Cookies and Site Data>Delete cookies and site data when Thunderbird is closed ***/
 user_pref("network.cookie.lifetimePolicy", 2);
-/* 2710: disable DOM (Document Object Model) Storage
- * [WARNING] This will break a LOT of sites' functionality AND extensions!
- * You are better off using an extension for more granular control ***/
-user_pref("dom.storage.enabled", false);
-/* 2730: disable offline cache ***/
-user_pref("browser.cache.offline.enable", false);
+/* 2710: enable Enhanced Tracking Protection (ETP) in all windows
+ * [SETTING] Privacy & Security>Enhanced Tracking Protection>Custom>Tracking content
+ * [SETTING] to add site exceptions: Urlbar>ETP Shield
+ * [SETTING] to manage site exceptions: Options>Privacy & Security>Enhanced Tracking Protection>Manage Exceptions ***/
+user_pref("privacy.trackingprotection.enabled", true);
+/* 2711: enable various ETP lists ***/
+user_pref("privacy.trackingprotection.socialtracking.enabled", true);
+user_pref("privacy.trackingprotection.cryptomining.enabled", true); // [DEFAULT: true]
+user_pref("privacy.trackingprotection.fingerprinting.enabled", true); // [DEFAULT: true]
 /* 2740: disable service worker cache and cache storage
- * [NOTE] We clear service worker cache on exiting Firefox (see 2803)
- * [NOTE] Unlike arkenfox/user.js, we explicitly disable it
+ * [NOTE] We clear service worker cache on exit (2803)
  * [1] https://w3c.github.io/ServiceWorker/#privacy ***/
 user_pref("dom.caches.enabled", false);
 /* 2750: disable Storage API [FF51+]
@@ -1010,24 +852,28 @@ user_pref("dom.caches.enabled", false);
  * [3] https://blog.mozilla.org/l10n/2017/03/07/firefox-l10n-report-aurora-54/ ***/
 user_pref("dom.storageManager.enabled", false);
 /* 2755: disable Storage Access API [FF65+]
- * [1] https://developer.mozilla.org/en-US/docs/Web/API/Storage_Access_API ***/
-   // user_pref("dom.storage_access.enabled", false); // [DEFAULT: false]
+ * [1] https://developer.mozilla.org/docs/Web/API/Storage_Access_API ***/
+user_pref("dom.storage_access.enabled", false);
+/* 2760: enable Local Storage Next Generation (LSNG) [FF65+] ***/
+user_pref("dom.storage.next_gen", true); // [DEFAULT: true FF92+]
 
 /*** [SECTION 2800]: SHUTDOWN
-     You should set the values to what suits you best.
-     - "Offline Website Data" includes appCache (2730), localStorage (2710),
-       service worker cache (2740), and QuotaManager (IndexedDB (2720), asm-cache)
-     - In both 2803 + 2804, the 'download' and 'history' prefs are combined in the
-       Firefox interface as "Browsing & Download History" and their values will be synced
+   * Sanitizing on shutdown is all or nothing. It does not use Managed Exceptions under
+     Privacy & Security>Delete cookies and site data when Thunderbird is closed (1681701)
+   * If you want to keep some sites' cookies (exception as "Allow") and optionally other site
+     data but clear all the rest on close, then you need to set the "cookie" and optionally the
+     "offlineApps" prefs below to false, and to set the cookie lifetime pref to 2 (2703)
 ***/
 user_pref("_user.js.parrot", "2800 syntax error: the parrot's bleedin' demised!");
-/* 2802: enable Thunderbird to clear items on shutdown (see 2803)
+/* 2802: enable Thunderbird to clear items on shutdown (2803)
+ * [SETTING] Privacy & Security>History>Custom Settings>Clear history when Thunderbird closes ***/
 user_pref("privacy.sanitize.sanitizeOnShutdown", true);
 /* 2803: set what items to clear on shutdown (if 2802 is true) [SETUP-CHROME]
- * [NOTE] If 'history' is true, downloads will also be cleared regardless of the value
- * but if 'history' is false, downloads can still be cleared independently
- * However, this may not always be the case. The interface combines and syncs these
- * prefs when set from there, and the sanitize code may change at any time ***/
+ * [NOTE] If "history" is true, downloads will also be cleared
+ * [NOTE] Active Logins: does not refer to logins via cookies, but rather HTTP Basic Authentication [1]
+ * [NOTE] Offline Website Data: localStorage, service worker cache, QuotaManager (IndexedDB, asm-cache)
+ * [SETTING] Privacy & Security>History>Custom Settings>Clear history when Thunderbird closes>Settings
+ * [1] https://en.wikipedia.org/wiki/Basic_access_authentication ***/
 user_pref("privacy.clearOnShutdown.cache", true);
 user_pref("privacy.clearOnShutdown.cookies", true);
 user_pref("privacy.clearOnShutdown.downloads", true); // see note above
@@ -1038,18 +884,29 @@ user_pref("privacy.clearOnShutdown.sessions", true); // Active Logins
 user_pref("privacy.clearOnShutdown.siteSettings", false); // Site Preferences
 /* 2804: reset default items to clear with Ctrl-Shift-Del (to match 2803) [SETUP-CHROME]
  * This dialog can also be accessed from the menu History>Clear Recent History
- * Firefox remembers your last choices. This will reset them when you start Firefox.
- * [NOTE] Regardless of what you set privacy.cpd.downloads to, as soon as the dialog
- * for "Clear Recent History" is opened, it is synced to the same as 'history' ***/
+ * Thunderbird remembers your last choices. This will reset them when you start Thunderbird
+ * [NOTE] Regardless of what you set "downloads" to, as soon as the dialog
+ * for "Clear Recent History" is opened, it is synced to the same as "history" ***/
 user_pref("privacy.cpd.cache", true);
 user_pref("privacy.cpd.cookies", true);
+   // user_pref("privacy.cpd.downloads", true); // not used, see note above
+user_pref("privacy.cpd.formdata", true); // Form & Search History
 user_pref("privacy.cpd.history", true); // Browsing & Download History
-/* 2806: reset default 'Time range to clear' for 'Clear Recent History' (see 2804)
- * Firefox remembers your last choice. This will reset the value when you start Firefox.
- * 0=everything, 1=last hour, 2=last two hours, 3=last four hours,
- * 4=today, 5=last five minutes, 6=last twenty-four hours
- * [NOTE] The values 5 + 6 are not listed in the dropdown, which will display a
- * blank value if they are used, but they do work as advertised ***/
+user_pref("privacy.cpd.offlineApps", true); // Offline Website Data
+user_pref("privacy.cpd.passwords", false); // this is not listed
+user_pref("privacy.cpd.sessions", true); // Active Logins
+user_pref("privacy.cpd.siteSettings", false); // Site Preferences
+/* 2805: clear Session Restore data when sanitizing on shutdown or manually [FF34+]
+ * [NOTE] Not needed if Session Restore is not used (0102) or is already cleared with history (2803)
+ * [NOTE] privacy.clearOnShutdown.openWindows prevents resuming from crashes (also see 5008)
+ * [NOTE] privacy.cpd.openWindows has a bug that causes an additional window to open ***/
+   // user_pref("privacy.clearOnShutdown.openWindows", true);
+   // user_pref("privacy.cpd.openWindows", true);
+/* 2806: reset default "Time range to clear" for "Clear Recent History" (2804)
+ * Thunderbird remembers your last choice. This will reset the value when you start Thunderbird
+ * 0=everything, 1=last hour, 2=last two hours, 3=last four hours, 4=today
+ * [NOTE] Values 5 (last 5 minutes) and 6 (last 24 hours) are not listed in the dropdown,
+ * which will display a blank value, and are not guaranteed to work ***/
 user_pref("privacy.sanitize.timeSpan", 0);
 
 /*** [SECTION 4000]: FPI (FIRST PARTY ISOLATION)

--- a/user.js
+++ b/user.js
@@ -78,14 +78,13 @@ user_pref("browser.aboutConfig.showWarning", false);
 /*** [SECTION 0100]: STARTUP ***/
 user_pref("_user.js.parrot", "0100 syntax error: the parrot's dead!");
 /* 0101: disable default browser check
- * [SETTING] Edit>Preferences>Advanced>Always check to see if Thunderbird is the default mail client on startup ***/
+ * [SETTING] General > System Integration > Always check to see if Thunderbird is the default... ***/
 user_pref("mail.shell.checkDefaultClient", false);
 /* 0102: set START page [SETUP-CHROME]
- * [SETTING] Edit>Preferences>General>Thunderbird Start Page ***/
+ * [SETTING] General > Thunderbird Start Page ***/
 user_pref("mailnews.start_page.enabled", false);
 /* 0104: set NEWTAB page
- * true=Activity Stream (default, see 0105), false=blank page
- * [SETTING] Home>New Windows and Tabs>New tabs ***/
+ * true=Activity Stream (default), false=blank page ***/
 user_pref("browser.newtabpage.enabled", false);
 
 /*** [SECTION 0200]: GEOLOCATION / LANGUAGE / LOCALE ***/
@@ -106,7 +105,7 @@ user_pref("browser.region.update.enabled", false); // [FF79+]
  * [NOTE] May not be hidden if Thunderbird has changed your settings due to your region (0203) ***/
    // user_pref("browser.search.region", "US"); // [HIDDEN PREF]
 /* 0210: set preferred language for displaying pages
- * [SETTING] General>Language and Appearance>Language>Choose your preferred language...
+ * [SETTING] General > Language & Appearance > Language > Choose the language used to display...
  * [TEST] https://addons.mozilla.org/about ***/
 user_pref("intl.accept_languages", "en-US, en");
 /* 0210b: Set dictionary to US ***/
@@ -127,17 +126,16 @@ user_pref("javascript.use_us_english_locale", true); // [HIDDEN PREF]
 user_pref("_user.js.parrot", "0300 syntax error: the parrot's not pinin' for the fjords!");
 /** UPDATES ***/
 /* 0301: disable auto-INSTALLING Thunderbird updates [NON-WINDOWS]
- * [NOTE] You will still get prompts to update, and should do so in a timely manner
- * [SETTING] General>Thunderbird Updates>Check for updates but let you choose to install them... ***/
+ * [NOTE] You will still get prompts to update, and should do so in a timely manner ***/
 user_pref("app.update.auto", false);
 /* 0302: disable auto-INSTALLING Thunderbird updates via a background service [FF90+] [WINDOWS]
- * [SETTING] General>Thunderbird Updates>Automatically install updates>Use a background service to install updates
+ * [SETTING] General > Thunderbird Updates > Automatically install updates > Use a background service to install updates
  * [1] https://support.mozilla.org/kb/enable-background-updates-firefox-windows ***/
 user_pref("app.update.background.scheduling.enabled", false);
 /* 0303: disable auto-CHECKING for extension and theme updates ***/
    // user_pref("extensions.update.enabled", false);
 /* 0304: disable auto-INSTALLING extension and theme updates (after the check in 0303)
- * [SETTING] about:addons>Extensions>[cog-wheel-icon]>Update Add-ons Automatically (toggle) ***/
+ * [SETTING] about:addons > Extensions > [cog-wheel-icon] > Update Add-ons Automatically (toggle) ***/
    // user_pref("extensions.update.autoUpdateDefault", false);
 /* 0305: disable extension metadata
  * used when installing/updating an extension, and in daily background update checks:
@@ -160,7 +158,7 @@ user_pref("extensions.htmlaboutaddons.recommendations.enabled", false);
  * [1] https://bugzilla.mozilla.org/1195552 ***/
 user_pref("datareporting.policy.dataSubmissionEnabled", false);
 /* 0331: disable Health Reports
- * [SETTING] Privacy & Security>Thunderbird Data Collection & Use>Allow Thunderbird to send technical... data ***/
+ * [SETTING] Privacy & Security > Thunderbird Data Collection and Use > Allow Thunderbird to send technical... ***/
 user_pref("datareporting.healthreport.uploadEnabled", false);
 /* 0332: disable telemetry
  * The "unified" pref affects the behaviour of the "enabled" pref
@@ -203,7 +201,7 @@ user_pref("breakpad.reportURL", "");
 user_pref("browser.tabs.crashReporting.sendReport", false); // [FF44+]
    // user_pref("browser.crashReports.unsubmittedCheck.enabled", false); // [FF51+] [DEFAULT: false]
 /* 0351: enforce no submission of backlogged Crash Reports [FF58+]
- * [SETTING] Privacy & Security>Thunderbird Data Collection & Use>Allow Thunderbird to send backlogged crash reports  ***/
+ * [SETTING] Privacy & Security > Thunderbird Data Collection and Use > Allow Thunderbird to send backlogged crash reports... ***/
 user_pref("browser.crashReports.unsubmittedCheck.autoSubmit2", false); // [DEFAULT: false]
 
 /** OTHER ***/
@@ -248,13 +246,11 @@ user_pref("mail.rights.override", true);  // [DEFAULT: unset]
 ***/
 user_pref("_user.js.parrot", "0400 syntax error: the parrot's passed on!");
 /* 0401: disable SB (Safe Browsing)
- * [WARNING] Do this at your own risk! These are the master switches
- * [SETTING] Privacy & Security>Security>... Block dangerous and deceptive content ***/
+ * [WARNING] Do this at your own risk! These are the master switches ***/
    // user_pref("browser.safebrowsing.malware.enabled", false);
    // user_pref("browser.safebrowsing.phishing.enabled", false);
 /* 0402: disable SB checks for downloads (both local lookups + remote)
- * This is the master switch for the safebrowsing.downloads* prefs (0403, 0404)
- * [SETTING] Privacy & Security>Security>... "Block dangerous downloads" ***/
+ * This is the master switch for the safebrowsing.downloads* prefs (0403, 0404) ***/
    // user_pref("browser.safebrowsing.downloads.enabled", false);
 /* 0403: disable SB checks for downloads (remote)
  * To verify the safety of certain executable files, Thunderbird may submit some information about the
@@ -263,8 +259,7 @@ user_pref("_user.js.parrot", "0400 syntax error: the parrot's passed on!");
  * [SETUP-SECURITY] If you do not understand this, or you want this protection, then override it ***/
 user_pref("browser.safebrowsing.downloads.remote.enabled", false);
 user_pref("browser.safebrowsing.downloads.remote.url", "");
-/* 0404: disable SB checks for unwanted software
- * [SETTING] Privacy & Security>Security>... "Warn you about unwanted and uncommon software" ***/
+/* 0404: disable SB checks for unwanted software ***/
    // user_pref("browser.safebrowsing.downloads.remote.block_potentially_unwanted", false);
    // user_pref("browser.safebrowsing.downloads.remote.block_uncommon", false);
 /* 0405: disable "ignore this warning" on SB warnings [FF45+]
@@ -359,20 +354,17 @@ user_pref("keyword.enabled", false);  // [DEFAULT: false]
 user_pref("browser.fixup.alternate.enabled", false);
 /* 0804: disable live search suggestions
  * [NOTE] Both must be true for the location bar to work
- * [SETUP-CHROME] Change these if you trust and use a privacy respecting search engine
- * [SETTING] Search>Provide search suggestions | Show search suggestions in address bar results ***/
+ * [SETUP-CHROME] Change these if you trust and use a privacy respecting search engine ***/
 user_pref("browser.search.suggest.enabled", false);
 /* 0810: disable search and form history
  * [SETUP-WEB] Be aware that autocomplete form data can be read by third parties [1][2]
  * [NOTE] We also clear formdata on exit (2803)
- * [SETTING] Privacy & Security>History>Custom Settings>Remember search and form history
  * [1] https://blog.mindedsecurity.com/2011/10/autocompleteagain.html
  * [2] https://bugzilla.mozilla.org/381681 ***/
 user_pref("browser.formfill.enable", false);
 /* 0811: disable Form Autofill
  * [NOTE] Stored data is NOT secure (uses a JSON file)
  * [NOTE] Heuristics controls Form Autofill on forms without @autocomplete attributes
- * [SETTING] Privacy & Security>Forms and Autofill>Autofill addresses
  * [1] https://wiki.mozilla.org/Firefox/Features/Form_Autofill ***/
 user_pref("extensions.formautofill.addresses.enabled", false); // [FF55+]
 user_pref("extensions.formautofill.available", "off"); // [FF56+]
@@ -488,7 +480,7 @@ user_pref("security.tls.enable_0rtt_data", false);
  * OCSP (non-stapled) leaks information about the sites you visit to the CA (cert authority)
  * It's a trade-off between security (checking) and privacy (leaking info to the CA)
  * [NOTE] This pref only controls OCSP fetching and does not affect OCSP stapling
- * [SETTING] Privacy & Security>Security>Certificates>Query OCSP responder servers...
+ * [SETTING] Privacy & Security > Security > Certificates > Query OCSP responder servers...
  * [1] https://en.wikipedia.org/wiki/Ocsp ***/
 user_pref("security.OCSP.enabled", 1); // [DEFAULT: 1]
 /* 1212: set OCSP fetch failures (non-stapled, see 1211) to hard-fail [SETUP-WEB]
@@ -533,8 +525,6 @@ user_pref("security.pki.crlite_mode", 2);
 user_pref("security.mixed_content.block_display_content", true);
 /* 1244: enable HTTPS-Only mode in all windows [FF76+]
  * When the top-level is HTTPS, insecure subresources are also upgraded (silent fail)
- * [SETTING] to add site exceptions: Padlock>HTTPS-Only mode>On (after "Continue to HTTP Site")
- * [SETTING] Privacy & Security>HTTPS-Only Mode (and manage exceptions)
  * [TEST] http://example.com [upgrade]
  * [TEST] http://neverssl.com/ [no upgrade] ***/
 user_pref("dom.security.https_only_mode", true); // [FF76+]
@@ -598,7 +588,7 @@ user_pref("network.http.referer.XOriginPolicy", 2);
 user_pref("network.http.referer.XOriginTrimmingPolicy", 2);
 /* 1603: enable the DNT (Do Not Track) HTTP header
  * [NOTE] DNT is enforced with Enhanced Tracking Protection (2710)
- * [SETTING] Privacy & Security>Enhanced Tracking Protection>Send websites a "Do Not Track" signal... ***/
+ * [SETTING] Privacy & Security > Privacy > Web Content > Send websites a "Do Not Track" signal... ***/
 user_pref("privacy.donottrackheader.enabled", true);
 
 /*** [SECTION 1700]: CONTAINERS
@@ -609,13 +599,11 @@ user_pref("privacy.donottrackheader.enabled", true);
    [4] https://github.com/stoically/temporary-containers/wiki
 ***/
 user_pref("_user.js.parrot", "1700 syntax error: the parrot's bit the dust!");
-/* 1701: enable Container Tabs and its UI setting [FF50+]
- * [SETTING] General>Tabs>Enable Container Tabs ***/
+/* 1701: enable Container Tabs and its UI setting [FF50+] ***/
 user_pref("privacy.userContext.enabled", true);
 user_pref("privacy.userContext.ui.enabled", true);
 /* 1702: set behaviour on "+ Tab" button to display container menu on left click [FF74+]
- * [NOTE] The menu is always shown on long press and right click
- * [SETTING] General>Tabs>Enable Container Tabs>Settings>Select a container for each new tab ***/
+ * [NOTE] The menu is always shown on long press and right click ***/
    // user_pref("privacy.userContext.newTabContainerOnLeftClick.enabled", true);
 
 /*** [SECTION 2000]: PLUGINS / MEDIA / WEBRTC ***/
@@ -642,14 +630,12 @@ user_pref("media.gmp-provider.enabled", false);
 user_pref("media.gmp-widevinecdm.enabled", false);
 /* 2022: disable all DRM content (EME: Encryption Media Extension)
  * [SETUP-WEB] e.g. Netflix, Amazon Prime, Hulu, HBO, Disney+, Showtime, Starz, DirectTV
- * [SETTING] General>DRM Content>Play DRM-controlled content
  * [TEST] https://bitmovin.com/demos/drm
  * [1] https://www.eff.org/deeplinks/2017/10/drms-dead-canary-how-we-just-lost-web-what-we-learned-it-and-what-we-need-do-next ***/
 user_pref("media.eme.enabled", false);
 /* 2030: disable autoplay of HTML5 media [FF63+]
  * 0=Allow all, 1=Block non-muted media (default), 5=Block all
- * [NOTE] You can set exceptions under site permissions
- * [SETTING] Privacy & Security>Permissions>Autoplay>Settings>Default for all websites ***/
+ * [NOTE] You can set exceptions under site permissions ***/
 user_pref("media.autoplay.default", 5);
 /* 2031: disable autoplay of HTML5 media if you interacted with the site [FF78+]
  * 0=sticky (default), 1=transient, 2=user
@@ -706,8 +692,7 @@ user_pref("_user.js.parrot", "2400 syntax error: the parrot's kicked the bucket!
 user_pref("dom.disable_beforeunload", true);
 /* 2402: prevent scripts from moving and resizing open windows ***/
 user_pref("dom.disable_window_move_resize", true);
-/* 2403: block popup windows
- * [SETTING] Privacy & Security>Permissions>Block pop-up windows ***/
+/* 2403: block popup windows ***/
 user_pref("dom.disable_open_during_load", true);
 /* 2404: limit events that can cause a popup [SETUP-WEB] ***/
 user_pref("dom.popup_allowed_events", "click dblclick mousedown pointerdown");
@@ -715,7 +700,6 @@ user_pref("dom.popup_allowed_events", "click dblclick mousedown pointerdown");
 /*** [SECTION 2600]: MISCELLANEOUS ***/
 user_pref("_user.js.parrot", "2600 syntax error: the parrot's run down the curtain!");
 /* 2601: prevent accessibility services from accessing your browser [RESTART]
- * [SETTING] Privacy & Security>Permissions>Prevent accessibility services from accessing your browser (FF80 or lower)
  * [1] https://support.mozilla.org/kb/accessibility-services ***/
 user_pref("accessibility.force_disabled", 1);
 /* 2602: disable sending additional analytics to web servers
@@ -730,7 +714,6 @@ user_pref("browser.pagethumbnails.capturing_disabled", true); // [HIDDEN PREF]
 user_pref("browser.uitour.enabled", false);
 user_pref("browser.uitour.url", "");
 /* 2607: disable various developer tools in browser context
- * [SETTING] Devtools>Advanced Settings>Enable browser chrome and add-on debugging toolboxes
  * [1] https://github.com/pyllyukko/user.js/issues/179#issuecomment-246468676 ***/
 user_pref("devtools.chrome.enabled", false);
 /* 2608: reset remote debugging to disabled
@@ -760,8 +743,7 @@ user_pref("network.IDN_show_punycode", true);
  *   It doesn't break "state separation" of browser content (by not sharing with OS, independent apps).
  *   It maintains disk avoidance and application data isolation. It's convenient. You can still save to disk.
  * CONS: You may prefer a different pdf reader for security reasons
- * CAVEAT: JS can still force a pdf to open in-browser by bundling its own code
- * [SETTING] General>Applications>Portable Document Format (PDF) ***/
+ * CAVEAT: JS can still force a pdf to open in-browser by bundling its own code ***/
 user_pref("pdfjs.disabled", false); // [DEFAULT: false]
 user_pref("pdfjs.enableScripting", false); // [FF86+]
 /* 2621: disable links launching Windows Store on Windows 8/8.1/10 [WINDOWS] ***/
@@ -775,8 +757,7 @@ user_pref("permissions.delegation.enabled", false);
 
 /** DOWNLOADS ***/
 /* 2651: enable user interaction for security by always asking where to download
- * [SETUP-CHROME] On Android this blocks longtapping and saving images
- * [SETTING] General>Downloads>Always ask you where to save files ***/
+ * [SETUP-CHROME] On Android this blocks longtapping and saving images ***/
 user_pref("browser.download.useDownloadDir", false);
 /* 2652: disable adding downloads to the system's "recent documents" list ***/
 user_pref("browser.download.manager.addToRecentDocs", false);
@@ -817,7 +798,7 @@ user_pref("_user.js.parrot", "2700 syntax error: the parrot's joined the bleedin
  * Option 5 with FPI enabled (4001) is ignored and not shown, and option 4 used instead
  * [NOTE] You can set cookie exceptions under site permissions or use an extension
  * [NOTE] Enforcing category to custom ensures ETP related prefs are always honored
- * [SETTING] Privacy & Security>Enhanced Tracking Protection>Custom>Cookies
+ * [SETTING] Privacy & Security > Privacy > Web Content > Accept cookies from sites
  * [1] https://blog.mozilla.org/security/2021/02/23/total-cookie-protection/ ***/
 user_pref("network.cookie.cookieBehavior", 2);
 user_pref("browser.contentblocking.category", "custom");
@@ -830,12 +811,9 @@ user_pref("network.cookie.thirdparty.nonsecureSessionOnly", true); // [FF58+]
 /* 2703: delete cookies and site data on close
  * 0=keep until they expire (default), 2=keep until you close Thunderbird
  * [NOTE] The setting below is disabled (but not changed) if you block all cookies (2701 = 2)
- * [SETTING] Privacy & Security>Cookies and Site Data>Delete cookies and site data when Thunderbird is closed ***/
+ * [SETTING] Privacy & Security > Privacy > Web Content > Keep until: "I close Thunderbird" ***/
 user_pref("network.cookie.lifetimePolicy", 2);
-/* 2710: enable Enhanced Tracking Protection (ETP) in all windows
- * [SETTING] Privacy & Security>Enhanced Tracking Protection>Custom>Tracking content
- * [SETTING] to add site exceptions: Urlbar>ETP Shield
- * [SETTING] to manage site exceptions: Options>Privacy & Security>Enhanced Tracking Protection>Manage Exceptions ***/
+/* 2710: enable Enhanced Tracking Protection (ETP) in all windows ***/
 user_pref("privacy.trackingprotection.enabled", true);
 /* 2711: enable various ETP lists ***/
 user_pref("privacy.trackingprotection.socialtracking.enabled", true);
@@ -860,8 +838,7 @@ user_pref("dom.storage_access.enabled", false);
 user_pref("dom.storage.next_gen", true); // [DEFAULT: true FF92+]
 
 /*** [SECTION 2800]: SHUTDOWN
-   * Sanitizing on shutdown is all or nothing. It does not use Managed Exceptions under
-     Privacy & Security>Delete cookies and site data when Thunderbird is closed (1681701)
+   * Sanitizing on shutdown is all or nothing (no exception can be set)
    * If you want to keep some sites' cookies (exception as "Allow") and optionally other site
      data but clear all the rest on close, then you need to set the "cookie" and optionally the
      "offlineApps" prefs below to false, and to set the cookie lifetime pref to 2 (2703)
@@ -873,7 +850,6 @@ user_pref("privacy.sanitize.sanitizeOnShutdown", true);
  * [NOTE] If "history" is true, downloads will also be cleared
  * [NOTE] Active Logins: does not refer to logins via cookies, but rather HTTP Basic Authentication [1]
  * [NOTE] Offline Website Data: localStorage, service worker cache, QuotaManager (IndexedDB, asm-cache)
- * [SETTING] Privacy & Security>History>Custom Settings>Clear history when Thunderbird closes>Settings
  * [1] https://en.wikipedia.org/wiki/Basic_access_authentication ***/
 user_pref("privacy.clearOnShutdown.cache", true);
 user_pref("privacy.clearOnShutdown.cookies", true);
@@ -1039,7 +1015,7 @@ user_pref("privacy.resistFingerprinting.letterboxing", true); // [HIDDEN PREF]
    // user_pref("privacy.resistFingerprinting.exemptedDomains", "*.example.invalid");
    // user_pref("privacy.resistFingerprinting.testGranularityMask", 0);
 /* 4510: enforce no system colors
- * [SETTING] General>Language and Appearance>Fonts and Colors>Colors>Use system colors ***/
+ * [SETTING] General > Language & Appearance > Colors... > Use system colors ***/
 user_pref("browser.display.use_system_colors", false); // [DEFAULT: false]
 /* 4511: enforce non-native widget theme
  * Security: removes/reduces system API calls, e.g. win32k API [1]
@@ -1051,7 +1027,6 @@ user_pref("widget.non-native-theme.enabled", true); // [DEFAULT: true]
  * 1=most recent window or tab, 2=new window, 3=new tab
  * Stops malicious window sizes and some screen resolution leaks.
  * You can still right-click a link and open in a new window
- * [SETTING] General>Tabs>Open links in tabs instead of new windows
  * [TEST] https://arkenfox.github.io/TZP/tzp.html#screen
  * [1] https://gitlab.torproject.org/tpo/applications/tor-browser/-/issues/9881 ***/
 user_pref("browser.link.open_newwindow", 3); // [DEFAULT: 3]
@@ -1073,7 +1048,6 @@ user_pref("_user.js.parrot", "5000 syntax error: the parrot's taken 'is last bow
  * In fact, PB mode limits or removes the ability to control some of these, and you need to quit
  * Thunderbird to clear them. PB is best used as a one off window (Menu>New Private Window) to provide
  * a temporary self-contained new session. Close all Private Windows to clear the PB mode session.
- * [SETTING] Privacy & Security>History>Custom Settings>Always use private browsing mode
  * [1] https://wiki.mozilla.org/Private_Browsing
  * [2] https://support.mozilla.org/kb/common-myths-about-private-browsing ***/
    // user_pref("browser.privatebrowsing.autostart", true);
@@ -1082,8 +1056,7 @@ user_pref("_user.js.parrot", "5000 syntax error: the parrot's taken 'is last bow
 user_pref("browser.cache.memory.enable", false);
 user_pref("browser.cache.memory.capacity", 0);
 /* 5003: disable saving passwords
- * [NOTE] This does not clear any passwords already saved
- * [SETTING] Privacy & Security>Logins and Passwords>Ask to save logins and passwords for websites ***/
+ * [NOTE] This does not clear any passwords already saved ***/
 user_pref("signon.rememberSignons", false);
 /* 5004: disable permissions manager from writing to disk [FF41+] [RESTART]
  * [NOTE] This means any permission changes are session only
@@ -1108,12 +1081,10 @@ user_pref("browser.sessionstore.resume_from_crash", false);
  * [1] https://bugzilla.mozilla.org/1281959 ***/
    // user_pref("browser.download.forbid_open_with", true);
 /* 5013: disable browsing and download history
- * [NOTE] We also clear history and downloads on exit (2803)
- * [SETTING] Privacy & Security>History>Custom Settings>Remember browsing and download history ***/
+ * [NOTE] We also clear history and downloads on exit (2803) ***/
 user_pref("places.history.enabled", false);
 /* 5016: discourage downloading to desktop
- * 0=desktop, 1=downloads (default), 2=last used
- * [SETTING] To set your default "downloads": General>Downloads>Save files to ***/
+ * 0=desktop, 1=downloads (default), 2=last used ***/
    // user_pref("browser.download.folderList", 2);
 
 /*** [SECTION 5500]: OPTIONAL HARDENING
@@ -1420,14 +1391,14 @@ user_pref("mailnews.display.date_senders_timezone", false);
 /* 9130: Address book collection [SETUP-FEATURE]
  * Disable Thunderbird internal address book email collection
  * Consider using CardBook extension instead (https://addons.thunderbird.net/addon/cardbook/)
- * [SETTING] Preferences>Composition>Addressing>Automatically add outgoing e-mail addresses...
- * [SETTING][CARDBOOK] CardBook>Preferences>Email>Collect Outgoing Email ***/
+ * [SETTING] Preferences > Composition > Addressing > Automatically add outgoing e-mail addresses...
+ * [SETTING][CARDBOOK] CardBook > Preferences > Email > Collect Outgoing Email ***/
    // user_pref("mail.collect_addressbook", "jsaddrbook://history.sqlite");
 user_pref("mail.collect_email_address_outgoing", false);
 /* 9131: Only use email addresses, without their Display Names [CARDBOOK] [SETUP-FEATURE]
  * By default, CardBook extension incorporates contacts display names in addresses fields.
  * This could leak sensitive information to all recipients.
- * [SETTING][CARDBOOK] CardBook>Preferences>Email>Sending Emails>Only use email addresses... ***/
+ * [SETTING][CARDBOOK] CardBook > Preferences > Email > Sending Emails > Only use email addresses... ***/
 user_pref("extensions.cardbook.useOnlyEmail", true);
 
 /*** [SECTION 9200]: EMAIL COMPOSITION (ENCODING / FORMAT / VIEW)
@@ -1441,11 +1412,9 @@ user_pref("_user.js.parrot", "9200 syntax error: this parrot has got no mail!");
  * [2] https://bugzilla.mozilla.org/show_bug.cgi?id=214729
  * [3] https://stackoverflow.com/a/28531705 ***/
 user_pref("intl.fallbackCharsetList.ISO-8859-1", "UTF-8");
-/* 9202: Set encoding of incoming mail
- * [SETTING] Display > Advanced > Fonts & Encodings > Incoming Mail ***/
+/* 9202: Set encoding of incoming mail ***/
 user_pref("mailnews.view_default_charset", "UTF-8");
-/* 9203: Set encoding of outgoing mail
- * [SETTING] Display > Advanced > Fonts & Encodings > Outgoing Mail ***/
+/* 9203: Set encoding of outgoing mail ***/
 user_pref("mailnews.send_default_charset", "UTF-8");
 /* 9204: Forces encoding in reply to be the default charset
  * [1] https://bugzilla.mozilla.org/show_bug.cgi?id=234958#c2 ***/
@@ -1471,7 +1440,7 @@ user_pref("mail.SpellCheckBeforeSend", false);
  * 3=Include both plain text and HTML message bodies in message)
  * Email that is HTML should also have plaintext multipart for plain text users.
  * [1] https://drewdevault.com/2016/04/11/Please-use-text-plain-for-emails.html
- * [SETTING] Edit > Preferences > Send Options > Send the message in both plain text and HTML ***/
+ * [SETTING] Account Settings > Composition & Addressing > Composition > Compose messages in HTML format ***/
 user_pref("mail.default_html_action", 1);
 /* 9212: Send email in plaintext unless expressly overridden.
  * [SETUP-FEATURE] Sometimes HTML is useful especially when used with Markdown Here
@@ -1483,7 +1452,7 @@ user_pref("mail.html_compose", false);
 user_pref("mail.identity.default.compose_html", false);
 /* 9213: Downgrade email to plaintext by default
  * [SETUP-FEATURE] Only use HTML email if you need it, see above
- * [SETTING] Edit > Preferences > Composition > Send Options > Send messages as plain-text if possible ***/
+ * [SETTING] Composition > Composition > HTML Style > Configure text format behavior > Send options... > Send messages as plain text if possible ***/
 user_pref("mailnews.sendformat.auto_downgrade", false);
 /* 9214: What classes can process incoming data.
  * (0=All classes (default), 1=Don't display HTML, 2=Don't display HTML and inline images,
@@ -1574,7 +1543,7 @@ user_pref("calendar.useragent.extra", "");
  * By default, extensive system detection would be performed to find user's current timezone.
  * Setting this preference to "UTC" should disable it.
  * You may also directly set it to your timezone, i.e. "Pacific/Fakaofo"
- * [SETTING] Edit>Preferences>Calendar>Calendar>Timezone ***/
+ * [SETTING] Calendar > Calendar > Timezone ***/
 user_pref("calendar.timezone.local", "UTC");  // [DEFAULT: ""]
 
 /** RSS ***/

--- a/user.js
+++ b/user.js
@@ -1,182 +1,175 @@
 /******
 * name: thunderbird user.js
-* date: 28 August 2021
-* version: v78.0
+* date: 12 September 2021
+* version: v91-beta
 * url: https://github.com/HorlogeSkynet/thunderbird-user.js
 * license: MIT (https://github.com/HorlogeSkynet/thunderbird-user.js/blob/master/LICENSE)
 * releases: https://github.com/HorlogeSkynet/thunderbird-user.js/releases
 
 * README:
-  0. Consider using Tor
-  1. READ the full README
-    * https://github.com/HorlogeSkynet/thunderbird-user.js/blob/master/README.md
-  2. READ this
-    * https://github.com/HorlogeSkynet/thunderbird-user.js/wiki/1.3-Implementation
-  3. If you skipped steps 1 and 2 above (shame on you), then here is the absolute minimum
-    * Auto-installing updates for Thunderbird and extensions are disabled (section 0302)
-    * Real time binary checks with Google services are disabled (section 0412)
-    * Browsing related technologies, and JavaScript disabled. Use your web browser for browsing.
-    * You will need to make changes, and to troubleshoot at times (choose wisely, there is always a trade-off).
-       While not 100% definitive, search for "[SETUP". If required, add each pref to your overrides section at
-       default values (or comment them out and reset them in about:config). Here are the main ones:
+
+  1. Consider using Tor if it meets your needs or fits your threat model
+       * https://www.torproject.org/about/torusers.html.en
+  2. Required reading: Overview, Backing Up, and Implementation entries
+       * https://github.com/HorlogeSkynet/thunderbird-user.js/wiki
+  3. If you skipped step 2, return to step 2
+  4. Make changes
+       * There are often trade-offs and conflicts between security vs privacy vs anti-fingerprinting
+         and these need to be balanced against functionality & convenience & breakage
+       * Some site breakage and unintended consequences will happen. Everyone's experience will differ
+         e.g. some user data is erased on close (section 2800), change this to suit your needs
+       * While not 100% definitive, search for "[SETUP" tags
+         e.g. wanna re-enable account auto configuration? check 9101 & 9102
+       * Take the wiki link in step 2 and read the Troubleshooting entry
+  5. Some tag info
         [SETUP-INSTALL] if you experience any issue during Thunderbird setting up, read it
         [SETUP-FEATURE] if you miss some (expected) Thunderbird features, read it
        [SETUP-SECURITY] it's one item, read it
             [SETUP-WEB] can cause some websites to break
-         [SETUP-CHROME] changes how Thunderbird itself behaves (i.e. NOT directly website related)
-           [SETUP-PERF] may impact performance
-         [SETUP-HARDEN] maybe you should consider using the Tor Browser
-    * [WARNING] tags are extra special and used sparingly, so heed them
-  4. BACKUP your profile folder before implementing (and/or test in a new/cloned profile)
-  5. KEEP UP TO DATE: https://github.com/arkenfox/user.js/wiki#small_orange_diamond-maintenance
+         [SETUP-CHROME] changes how Thunderbird itself behaves (i.e. not directly website related)
 
 * INDEX:
+
   0100: STARTUP
   0200: GEOLOCATION / LANGUAGE / LOCALE
-  0300: QUIET BIRD
-  0400: BLOCKLISTS / SAFE BROWSING
-  0500: SYSTEM ADD-ONS / EXPERIMENTS
+  0300: QUIETER BIRD
+  0400: SAFE BROWSING
   0600: BLOCK IMPLICIT OUTBOUND
-  0700: HTTP* / TCP/IP / DNS / PROXY / SOCKS etc
-  0800: HISTORY / FORMS
-  1000: CACHE / FAVICONS
-  1200: HTTPS (SSL/TLS / OCSP / CERTS / HPKP / CIPHERS)
+  0700: DNS / DoH / PROXY / SOCKS / IPv6
+  0800: LOCATION BAR / SEARCH BAR / SUGGESTIONS / HISTORY / FORMS
+  0900: PASSWORDS
+  1000: DISK AVOIDANCE
+  1200: HTTPS (SSL/TLS / OCSP / CERTS / HPKP)
   1400: FONTS
   1600: HEADERS / REFERERS
-  1800: PLUGINS
-  2000: MEDIA / CAMERA / MIC
-  2200: WINDOW MEDDLING & LEAKS / POPUPS
+  1700: CONTAINERS
+  2000: PLUGINS / MEDIA / WEBRTC
   2300: WEB WORKERS
-  2400: DOM (DOCUMENT OBJECT MODEL) & JAVASCRIPT
+  2400: DOM (DOCUMENT OBJECT MODEL)
+  2500: FINGERPRINTING
   2600: MISCELLANEOUS
   2700: PERSISTENT STORAGE
   2800: SHUTDOWN
   4000: FPI (FIRST PARTY ISOLATION)
   4500: RFP (RESIST FINGERPRINTING)
-  4600: RFP ALTERNATIVES
-  4700: RFP ALTERNATIVES (NAVIGATOR / USER AGENT (UA) SPOOFING)
-  5000: PERSONAL
-  6000: THUNDERBIRD (AUTO CONFIG / UI / HEADERS / ADDRESS BOOK)
-  6100: EMAIL COMPOSITION (ENCODING / FORMAT / VIEW)
-  6200: OTHER THUNDERBIRD COMPONENTS (CHAT / CALENDAR / RSS)
-  6300: THUNDERBIRD ENCRYPTION (ENIGMAIL / AUTOCRYPT / GNUPG)
+  5000: OPTIONAL OPSEC
+  5500: OPTIONAL HARDENING
+  6000: DON'T TOUCH
+  7000: DON'T BOTHER
+  8000: DON'T BOTHER: NON-RFP
+  9000: PERSONAL
+  9100: THUNDERBIRD (AUTO CONFIG / UI / HEADERS / ADDRESS BOOK)
+  9200: EMAIL COMPOSITION (ENCODING / FORMAT / VIEW)
+  9300: OTHER THUNDERBIRD COMPONENTS (CHAT / CALENDAR / RSS)
+  9400: THUNDERBIRD ENCRYPTION (ENIGMAIL / AUTOCRYPT / GNUPG)
   9999: DEPRECATED / REMOVED / LEGACY / RENAMED
 
 ******/
 
 /* START: internal custom pref to test for syntax errors
- * [NOTE] In FF60+, not all syntax errors cause parsing to abort i.e. reaching the last debug
- * pref no longer necessarily means that all prefs have been applied. Check the console right
+ * [NOTE] Not all syntax errors cause parsing to abort i.e. reaching the last debug pref
+ * no longer necessarily means that all prefs have been applied. Check the console right
  * after startup for any warnings/error messages related to non-applied prefs
  * [1] https://blog.mozilla.org/nnethercote/2018/03/09/a-new-preferences-parser-for-firefox/ ***/
 user_pref("_user.js.parrot", "START: Oh yes, the Norwegian Blue... what's wrong with it?");
 
-/* 0000: disable about:config warning
- * FF71-72: chrome://global/content/config.xul
- * FF73+: chrome://global/content/config.xhtml ***/
-user_pref("general.warnOnAboutConfig", false); // XUL/XHTML version
-user_pref("browser.aboutConfig.showWarning", false); // HTML version [FF71+]
+/* 0000: disable about:config warning ***/
+user_pref("browser.aboutConfig.showWarning", false);
 
 /*** [SECTION 0100]: STARTUP ***/
 user_pref("_user.js.parrot", "0100 syntax error: the parrot's dead!");
 /* 0101: disable default browser check
  * [SETTING] Edit>Preferences>Advanced>Always check to see if Thunderbird is the default mail client on startup ***/
 user_pref("mail.shell.checkDefaultClient", false);
-/* 0102: set START page
+/* 0102: set START page [SETUP-CHROME]
  * [SETTING] Edit>Preferences>General>Thunderbird Start Page ***/
 user_pref("mailnews.start_page.enabled", false);
 
 /*** [SECTION 0200]: GEOLOCATION / LANGUAGE / LOCALE ***/
 user_pref("_user.js.parrot", "0200 syntax error: the parrot's definitely deceased!");
-/** GEOLOCATION ***/
-/* 0201: disable Location-Aware Browsing
- * [NOTE] Best left at default "true", fingerprintable, is already behind a prompt (see 0202)
- * [1] https://www.mozilla.org/firefox/geolocation/ ***/
-user_pref("geo.enabled", false);
-/* 0202: set a default permission for Location (see 0201) [FF58+]
- * 0=always ask (default), 1=allow, 2=block
- * [NOTE] Best left at default "always ask", fingerprintable via Permissions API
- * [SETTING] to add site exceptions: Page Info>Permissions>Access Your Location
- * [SETTING] to manage site exceptions: Options>Privacy & Security>Permissions>Location>Settings ***/
-   // user_pref("permissions.default.geo", 2);
-/* 0203: use Mozilla geolocation service instead of Google when geolocation is enabled [FF74+]
+/* 0201: use Mozilla geolocation service instead of Google if permission is granted [FF74+]
  * Optionally enable logging to the console (defaults to false) ***/
 user_pref("geo.provider.network.url", "https://location.services.mozilla.com/v1/geolocate?key=%MOZILLA_API_KEY%");
    // user_pref("geo.provider.network.logging.enabled", true); // [HIDDEN PREF]
-/* 0204: disable using the OS's geolocation service ***/
+/* 0202: disable using the OS's geolocation service ***/
 user_pref("geo.provider.ms-windows-location", false); // [WINDOWS]
 user_pref("geo.provider.use_corelocation", false); // [MAC]
 user_pref("geo.provider.use_gpsd", false); // [LINUX]
-/* 0206: disable geographically specific results/search engines e.g. "browser.search.*.US"
- * i.e. ignore all of Mozilla's various search engines in multiple locales ***/
-user_pref("browser.search.geoSpecificDefaults", false);
-user_pref("browser.search.geoSpecificDefaults.url", "");
-
-/** LANGUAGE / LOCALE ***/
+/* 0203: disable region updates
+ * [1] https://firefox-source-docs.mozilla.org/toolkit/modules/toolkit_modules/Region.html ***/
+user_pref("browser.region.network.url", ""); // [FF78+]
+user_pref("browser.region.update.enabled", false); // [[FF79+]
+/* 0204: set search region
+ * [NOTE] May not be hidden if Thunderbird has changed your settings due to your region (0203) ***/
+   // user_pref("browser.search.region", "US"); // [HIDDEN PREF]
 /* 0210: set preferred language for displaying web pages
  * [TEST] https://addons.mozilla.org/about ***/
 user_pref("intl.accept_languages", "en-US, en");
 /* 0210b: Set dictionary to US ***/
 user_pref("spellchecker.dictionary", "en-US");
-/* 0211: enforce US English locale regardless of the system locale
- * [SETUP-WEB] May break some input methods e.g xim/ibus for CJK languages, see [2]
- * [1] https://bugzilla.mozilla.org/867501
- * [2] https://bugzilla.mozilla.org/1629630 ***/
+/* 0211: use US English locale regardless of the system locale
+ * [SETUP-WEB] May break some input methods e.g xim/ibus for CJK languages [1]
+ * [1] https://bugzilla.mozilla.org/buglist.cgi?bug_id=867501,1629630 ***/
 user_pref("javascript.use_us_english_locale", true); // [HIDDEN PREF]
-/* 0212: enforce fallback text encoding to match en-US
- * When the content or server doesn't declare a charset the browser will
- * fallback to the "Current locale" based on your application language
- * [SETTING] General>Language and Appearance>Fonts and Colors>Advanced>Text Encoding for Legacy Content (FF72-)
- * [TEST] https://hsivonen.com/test/moz/check-charset.htm
- * [1] https://gitlab.torproject.org/tpo/applications/tor-browser/-/issues/20025 ***/
-user_pref("intl.charset.fallback.override", "windows-1252");
 
 /*** [SECTION 0300]: QUIET BIRD
      Starting in user.js v68, we only disable the auto-INSTALL of Thunderbird.
      You still get prompts to update, in one click.
      We have NEVER disabled auto-CHECKING, and highly discourage that.
-     Previously we also disabled auto-INSTALLING of extensions (0302b).
      There are many legitimate reasons to turn off auto-INSTALLS, including hijacked or monetized
      extensions, time constraints, legacy issues, dev/testing, and fear of breakage/bugs. It is
      still important to do updates for security reasons, please do so manually if you make changes.
 ***/
 user_pref("_user.js.parrot", "0300 syntax error: the parrot's not pinin' for the fjords!");
-/* 0301b: disable auto-CHECKING for extension and theme updates ***/
-   // user_pref("extensions.update.enabled", false);
-/* 0302a: disable auto-INSTALLING Thunderbird updates [SETUP-INSTALL] [NON-WINDOWS FF65+]
- * [NOTE] In FF65+ on Windows this SETTING (below) is now stored in a file and the pref was removed
+/** UPDATES ***/
+/* 0301: disable auto-INSTALLING Thunderbird updates [NON-WINDOWS]
+ * [NOTE] You will still get prompts to update, and should do so in a timely manner
  * [SETTING] General>Thunderbird Updates>Check for updates but let you choose to install them... ***/
 user_pref("app.update.auto", false);
-/* 0302b: disable auto-INSTALLING extension and theme updates (after the check in 0301b)
+/* 0302: disable auto-INSTALLING Thunderbird updates via a background service [FF90+] [WINDOWS]
+ * [SETTING] General>Thunderbird Updates>Automatically install updates>Use a background service to install updates
+ * [1] https://support.mozilla.org/kb/enable-background-updates-firefox-windows ***/
+user_pref("app.update.background.scheduling.enabled", false);
+/* 0303: disable auto-CHECKING for extension and theme updates ***/
+   // user_pref("extensions.update.enabled", false);
+/* 0304: disable auto-INSTALLING extension and theme updates (after the check in 0303)
  * [SETTING] about:addons>Extensions>[cog-wheel-icon]>Update Add-ons Automatically (toggle) ***/
    // user_pref("extensions.update.autoUpdateDefault", false);
-/* 0306: disable extension metadata
+/* 0305: disable extension metadata
  * used when installing/updating an extension, and in daily background update checks:
  * when false, extension detail tabs will have no description
  * [NOTE] Unlike arkenfox/user.js, we explicitly disable it ***/
 user_pref("extensions.getAddons.cache.enabled", false);
-/* 0308: disable search engine updates (e.g. OpenSearch)
- * [NOTE] This does not affect Mozilla's built-in or Web Extension search engines
- * [SETTING] General>Thunderbird Updates>Automatically update search engines (FF72-) ***/
+/* 0306: disable search engine updates (e.g. OpenSearch)
+ * [NOTE] This does not affect Mozilla's built-in or Web Extension search engines ***/
 user_pref("browser.search.update", false);
-/* 0310: disable sending the URL of the website where a plugin crashed ***/
-user_pref("dom.ipc.plugins.reportCrashURL", false);
-/* 0320: disable about:addons' Recommendations pane (uses Google Analytics) ***/
+/* 0307: disable System Add-on updates ***/
+user_pref("extensions.systemAddon.update.enabled", false); // [FF62+]
+user_pref("extensions.systemAddon.update.url", ""); // [FF44+]
+
+/** RECOMMENDATIONS ***/
+/* 0320: disable recommendation pane in about:addons (uses Google Analytics) ***/
 user_pref("extensions.getAddons.showPane", false); // [HIDDEN PREF]
 /* 0321: disable recommendations in about:addons' Extensions and Themes panes [FF68+] ***/
 user_pref("extensions.htmlaboutaddons.recommendations.enabled", false);
-/* 0330: disable telemetry
- * the pref (.unified) affects the behavior of the pref (.enabled)
- * IF unified=false then .enabled controls the telemetry module
- * IF unified=true then .enabled ONLY controls whether to record extended data
- * so make sure to have both set as false.
- * Restoring prompted=0 would make TB ask you on fresh install.
- * [NOTE] FF58+ 'toolkit.telemetry.enabled' is now LOCKED to reflect prerelease
- * or release builds (true and false respectively), see [2].
+
+/** TELEMETRY ***/
+/* 0330: disable new data submission [FF41+]
+ * If disabled, no policy is shown or upload takes place, ever
+ * [1] https://bugzilla.mozilla.org/1195552 ***/
+user_pref("datareporting.policy.dataSubmissionEnabled", false);
+/* 0331: disable Health Reports
+ * [SETTING] Privacy & Security>Thunderbird Data Collection & Use>Allow Thunderbird to send technical... data ***/
+user_pref("datareporting.healthreport.uploadEnabled", false);
+/* 0332: disable telemetry
+ * The "unified" pref affects the behaviour of the "enabled" pref
+ * - If "unified" is false then "enabled" controls the telemetry module
+ * - If "unified" is true then "enabled" only controls whether to record extended data
+ * [NOTE] "toolkit.telemetry.enabled" is now LOCKED to reflect prerelease (true) or release builds (false) [2]
  * [1] https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/internals/preferences.html
  * [2] https://medium.com/georg-fritzsche/data-preference-changes-in-firefox-58-2d5df9c428b5 ***/
 user_pref("toolkit.telemetry.unified", false);
-user_pref("toolkit.telemetry.enabled", false); // see [NOTE] above FF58+
+user_pref("toolkit.telemetry.enabled", false); // see [NOTE]
 user_pref("toolkit.telemetry.prompted", 2);
 user_pref("toolkit.telemetry.server", "data:,");
 user_pref("toolkit.telemetry.archive.enabled", false);
@@ -185,23 +178,45 @@ user_pref("toolkit.telemetry.shutdownPingSender.enabled", false); // [FF55+]
 user_pref("toolkit.telemetry.updatePing.enabled", false); // [FF56+]
 user_pref("toolkit.telemetry.bhrPing.enabled", false); // [FF57+] Background Hang Reporter
 user_pref("toolkit.telemetry.firstShutdownPing.enabled", false); // [FF57+]
-/* 0340: disable Health Reports
- * [SETTING] Privacy & Security>Thunderbird Data Collection & Use>Allow Thunderbird to send technical... data ***/
-user_pref("datareporting.healthreport.uploadEnabled", false);
-/* 0341: disable new data submission, master kill switch [FF41+]
- * If disabled, no policy is shown or upload takes place, ever
- * [1] https://bugzilla.mozilla.org/1195552 ***/
-user_pref("datareporting.policy.dataSubmissionEnabled", false);
-/* 0342: disable Studies (see 0503)
+/* 0333: disable Telemetry Coverage
+  * [1] https://blog.mozilla.org/data/2018/08/20/effectively-measuring-search-in-firefox/ ***/
+ user_pref("toolkit.telemetry.coverage.opt-out", true); // [HIDDEN PREF]
+ user_pref("toolkit.coverage.opt-out", true); // [FF64+] [HIDDEN PREF]
+ user_pref("toolkit.coverage.endpoint.base", "");
+/* 0334: disable PingCentre telemetry (used in several System Add-ons) [FF57+]
+ * Defense-in-depth: currently covered by 0331 ***/
+user_pref("browser.ping-centre.telemetry", false);
+
+/** STUDIES ***/
+/* 0340: disable Studies
  * [NOTE] This option is missing from Thunderbird's preferences panel (hidden?) ***/
 user_pref("app.shield.optoutstudies.enabled", false);
+/* 0341: disable Normandy/Shield [FF60+]
+ * Shield is a telemetry system that can push and test "recipes"
+ * [1] https://mozilla.github.io/normandy/ ***/
+user_pref("app.normandy.enabled", false);
+user_pref("app.normandy.api_url", "");
+
+/** CRASH REPORTS ***/
 /* 0350: disable Crash Reports ***/
 user_pref("breakpad.reportURL", "");
 user_pref("browser.tabs.crashReporting.sendReport", false); // [FF44+]
-user_pref("browser.crashReports.unsubmittedCheck.enabled", false); // [FF51+]
-/* 0351: disable backlogged Crash Reports
+   // user_pref("browser.crashReports.unsubmittedCheck.enabled", false); // [FF51+] [DEFAULT: false]
+/* 0351: enforce no submission of backlogged Crash Reports [FF58+]
  * [SETTING] Privacy & Security>Thunderbird Data Collection & Use>Allow Thunderbird to send backlogged crash reports  ***/
-user_pref("browser.crashReports.unsubmittedCheck.autoSubmit2", false); // [FF58+]
+user_pref("browser.crashReports.unsubmittedCheck.autoSubmit2", false); // [DEFAULT: false]
+
+/** OTHER ***/
+/* 0360: disable Captive Portal detection
+ * [1] https://www.eff.org/deeplinks/2017/08/how-captive-portals-interfere-wireless-security-and-privacy ***/
+user_pref("captivedetect.canonicalURL", "");
+user_pref("network.captive-portal-service.enabled", false); // [FF52+]
+/* 0361: disable Network Connectivity checks [FF65+]
+ * [1] https://bugzilla.mozilla.org/1460537 ***/
+user_pref("network.connectivity-service.enabled", false);
+/* 0362: enforce disabling of Web Compatibility Reporter [FF56+]
+ * Web Compatibility Reporter adds a "Report Site Issue" button to send data to Mozilla ***/
+user_pref("extensions.webcompat-reporter.enabled", false); // [DEFAULT: false]
 /* 0370: disable UI instrumentation ***/
 user_pref("mail.instrumentation.postUrl", "");
 user_pref("mail.instrumentation.askUser", false);
@@ -216,102 +231,44 @@ user_pref("mail.instrumentation.userOptedIn", false);
  * [1] https://searchfox.org/comm-esr78/rev/384830b0570096c48770398060f87fbe556f6f01/mail/base/content/specialTabs.js#1218 ***/
 user_pref("mail.rights.override", true);  // [DEFAULT: unset]
    // user_pref("mail.rights.version", 1)  // [DEFAULT: unset]
-/* 0390: disable Captive Portal detection
- * [1] https://www.eff.org/deeplinks/2017/08/how-captive-portals-interfere-wireless-security-and-privacy
- * [2] https://wiki.mozilla.org/Necko/CaptivePortal ***/
-user_pref("captivedetect.canonicalURL", "");
-user_pref("network.captive-portal-service.enabled", false); // [FF52+]
-/* 0391: disable Network Connectivity checks [FF65+]
- * [1] https://bugzilla.mozilla.org/1460537 ***/
-user_pref("network.connectivity-service.enabled", false);
 
-/*** [SECTION 0400]: BLOCKLISTS / SAFE BROWSING (SB) ***/
-user_pref("_user.js.parrot", "0400 syntax error: the parrot's passed on!");
-/** BLOCKLISTS ***/
-/* 0401: enforce Firefox blocklist
- * [NOTE] It includes updates for "revoked certificates"
- * [1] https://blog.mozilla.org/security/2015/03/03/revoking-intermediate-certificates-introducing-onecrl/ ***/
-user_pref("extensions.blocklist.enabled", true); // [DEFAULT: true]
+/*** [SECTION 0400]: SAFE BROWSING (SB)
+   SB has taken many steps to preserve privacy. If required, a full url is never sent
+   to Google, only a part-hash of the prefix, hidden with noise of other real part-hashes.
+   Firefox takes measures such as stripping out identifying parameters and since SBv4 (FF57+)
+   doesn't even use cookies. (#Turn on browser.safebrowsing.debug to monitor this activity)
+   FWIW, Google also swear it is anonymized and only used to flag malicious sites.
 
-/** SAFE BROWSING (SB)
-    Safe Browsing has taken many steps to preserve privacy. *IF* required, a full url is never
-    sent to Google, only a PART-hash of the prefix, and this is hidden with noise of other real
-    PART-hashes. Google also swear it is anonymized and only used to flag malicious sites.
-    Firefox also takes measures such as striping out identifying parameters and since SBv4 (FF57+)
-    doesn't even use cookies. (#Turn on browser.safebrowsing.debug to monitor this activity)
-
-    #Required reading [#] https://feeding.cloud.geek.nz/posts/how-safe-browsing-works-in-firefox/
-    [1] https://wiki.mozilla.org/Security/Safe_Browsing
-    [2] https://support.mozilla.org/en-US/kb/how-does-phishing-and-malware-protection-work
+   [1] https://feeding.cloud.geek.nz/posts/how-safe-browsing-works-in-firefox/
+   [2] https://wiki.mozilla.org/Security/Safe_Browsing
+   [3] https://support.mozilla.org/kb/how-does-phishing-and-malware-protection-work
 ***/
-/* 0410: disable SB (Safe Browsing)
- * [WARNING] Do this at your own risk! These are the master switches.
- * [SETTING] Privacy & Security>Security>... "Block dangerous and deceptive content" ***/
+user_pref("_user.js.parrot", "0400 syntax error: the parrot's passed on!");
+/* 0401: disable SB (Safe Browsing)
+ * [WARNING] Do this at your own risk! These are the master switches
+ * [SETTING] Privacy & Security>Security>... Block dangerous and deceptive content ***/
    // user_pref("browser.safebrowsing.malware.enabled", false);
    // user_pref("browser.safebrowsing.phishing.enabled", false);
-/* 0411: disable SB checks for downloads (both local lookups + remote)
- * This is the master switch for the safebrowsing.downloads* prefs (0412, 0413)
+/* 0402: disable SB checks for downloads (both local lookups + remote)
+ * This is the master switch for the safebrowsing.downloads* prefs (0403, 0404)
  * [SETTING] Privacy & Security>Security>... "Block dangerous downloads" ***/
    // user_pref("browser.safebrowsing.downloads.enabled", false);
-/* 0412: disable SB checks for downloads (remote)
- * To verify the safety of certain executable files, Firefox may submit some information about the
+/* 0403: disable SB checks for downloads (remote)
+ * To verify the safety of certain executable files, Thunderbird may submit some information about the
  * file, including the name, origin, size and a cryptographic hash of the contents, to the Google
- * Safe Browsing service which helps Firefox determine whether or not the file should be blocked
+ * Safe Browsing service which helps Thunderbird determine whether or not the file should be blocked
  * [SETUP-SECURITY] If you do not understand this, or you want this protection, then override it ***/
 user_pref("browser.safebrowsing.downloads.remote.enabled", false);
 user_pref("browser.safebrowsing.downloads.remote.url", "");
-/* 0413: disable SB checks for unwanted software
+/* 0404: disable SB checks for unwanted software
  * [SETTING] Privacy & Security>Security>... "Warn you about unwanted and uncommon software" ***/
    // user_pref("browser.safebrowsing.downloads.remote.block_potentially_unwanted", false);
    // user_pref("browser.safebrowsing.downloads.remote.block_uncommon", false);
-/* 0419: disable 'ignore this warning' on SB warnings
+/* 0405: disable "ignore this warning" on SB warnings [FF45+]
  * If clicked, it bypasses the block for that session. This is a means for admins to enforce SB
  * [TEST] see github wiki APPENDIX A: Test Sites: Section 5
  * [1] https://bugzilla.mozilla.org/1226490 ***/
    // user_pref("browser.safebrowsing.allowOverride", false);
-
-/*** [SECTION 0500]: SYSTEM ADD-ONS / EXPERIMENTS
-     System Add-ons are a method for shipping extensions, considered to be
-     built-in features to Firefox, that are hidden from the about:addons UI.
-     To view your System Add-ons go to about:support, they are listed under "Firefox Features"
-
-     Some System Add-ons have no on-off prefs. Instead you can manually remove them. Note that app
-     updates will restore them. They may also be updated and possibly restored automatically (see 0505)
-     * Portable: "...\App\Firefox64\browser\features\" (or "App\Firefox\etc" for 32bit)
-     * Windows: "...\Program Files\Mozilla\browser\features" (or "Program Files (X86)\etc" for 32bit)
-     * Mac: "...\Applications\Firefox\Contents\Resources\browser\features\"
-            [NOTE] On Mac you can right-click on the application and select "Show Package Contents"
-     * Linux: "/usr/lib/firefox/browser/features" (or similar)
-
-     [1] https://firefox-source-docs.mozilla.org/toolkit/mozapps/extensions/addon-manager/SystemAddons.html
-     [2] https://searchfox.org/mozilla-central/source/browser/extensions
-***/
-user_pref("_user.js.parrot", "0500 syntax error: the parrot's cashed in 'is chips!");
-/* 0503: disable Normandy/Shield [FF60+]
- * Shield is an telemetry system (including Heartbeat) that can also push and test "recipes"
- * [1] https://wiki.mozilla.org/Firefox/Shield
- * [2] https://github.com/mozilla/normandy ***/
-user_pref("app.normandy.enabled", false);
-user_pref("app.normandy.api_url", "");
-/* 0505: disable System Add-on updates ***/
-user_pref("extensions.systemAddon.update.enabled", false); // [FF62+]
-user_pref("extensions.systemAddon.update.url", ""); // [FF44+]
-/* 0506: disable PingCentre telemetry (used in several System Add-ons) [FF57+]
- * Currently blocked by 'datareporting.healthreport.uploadEnabled' (see 0340) ***/
-user_pref("browser.ping-centre.telemetry", false);
-/* 0517: disable Form Autofill
- * [NOTE] Stored data is NOT secure (uses a JSON file)
- * [NOTE] Heuristics controls Form Autofill on forms without @autocomplete attributes
- * [SETTING] Privacy & Security>Forms and Autofill>Autofill addresses (FF74+)
- * [1] https://wiki.mozilla.org/Firefox/Features/Form_Autofill
- * [2] https://www.ghacks.net/2017/05/24/firefoxs-new-form-autofill-is-awesome/ ***/
-user_pref("extensions.formautofill.addresses.enabled", false); // [FF55+]
-user_pref("extensions.formautofill.available", "off"); // [FF56+]
-user_pref("extensions.formautofill.creditCards.enabled", false); // [FF56+]
-user_pref("extensions.formautofill.heuristics.enabled", false); // [FF55+]
-/* 0518: disable Web Compatibility Reporter [FF56+]
- * Web Compatibility Reporter adds a "Report Site Issue" button to send data to Mozilla ***/
-user_pref("extensions.webcompat-reporter.enabled", false);
 
 /*** [SECTION 0600]: BLOCK IMPLICIT OUTBOUND [not explicitly asked for - e.g. clicked on] ***/
 user_pref("_user.js.parrot", "0600 syntax error: the parrot's no more!");
@@ -319,74 +276,46 @@ user_pref("_user.js.parrot", "0600 syntax error: the parrot's no more!");
  * [1] https://developer.mozilla.org/docs/Web/HTTP/Link_prefetching_FAQ ***/
 user_pref("network.prefetch-next", false);
 /* 0602: disable DNS prefetching
- * [1] https://www.ghacks.net/2013/04/27/firefox-prefetching-what-you-need-to-know/
- * [2] https://developer.mozilla.org/docs/Web/HTTP/Headers/X-DNS-Prefetch-Control ***/
+ * [1] https://developer.mozilla.org/docs/Web/HTTP/Headers/X-DNS-Prefetch-Control ***/
 user_pref("network.dns.disablePrefetch", true);
-user_pref("network.dns.disablePrefetchFromHTTPS", true); // [HIDDEN PREF ESR] [DEFAULT: true FF70+]
+   // user_pref("network.dns.disablePrefetchFromHTTPS", true); // [DEFAULT: true]
 /* 0603: disable predictor / prefetching ***/
 user_pref("network.predictor.enabled", false);
-user_pref("network.predictor.enable-prefetch", false); // [FF48+]
-/* 0605: disable link-mouseover opening connection to linked server
- * [1] https://news.slashdot.org/story/15/08/14/2321202/how-to-quash-firefoxs-silent-requests
- * [2] https://www.ghacks.net/2015/08/16/block-firefox-from-connecting-to-sites-when-you-hover-over-links/ ***/
+   // user_pref("network.predictor.enable-prefetch", false); // [FF48+] [DEFAULT: false]
+/* 0604: disable link-mouseover opening connection to linked server
+ * [1] https://news.slashdot.org/story/15/08/14/2321202/how-to-quash-firefoxs-silent-requests ***/
 user_pref("network.http.speculative-parallel-limit", 0);
-/* 0606: disable "Hyperlink Auditing" (click tracking) and enforce same host in case
+/* 0605: enforce no "Hyperlink Auditing" (click tracking)
  * [1] https://www.bleepingcomputer.com/news/software/major-browsers-to-prevent-disabling-of-click-tracking-privacy-risk/ ***/
-user_pref("browser.send_pings", false); // [DEFAULT: false]
-user_pref("browser.send_pings.require_same_host", true);
+   // user_pref("browser.send_pings", false); // [DEFAULT: false]
 /* 0610: don't refresh nor reload pages when tab/window is not active or in idle state
  * [1] https://bugzilla.mozilla.org/show_bug.cgi?id=518805 ***/
 user_pref("browser.meta_refresh_when_inactive.disabled", true);
 
-/*** [SECTION 0700]: HTTP* / TCP/IP / DNS / PROXY / SOCKS etc ***/
+/*** [SECTION 0700]: DNS / DoH / PROXY / SOCKS / IPv6 ***/
 user_pref("_user.js.parrot", "0700 syntax error: the parrot's given up the ghost!");
 /* 0701: disable IPv6
- * IPv6 can be abused, especially regarding MAC addresses. They also do not play nice
- * with VPNs. That's even assuming your ISP and/or router and/or website can handle it.
- * [STATS] Firefox telemetry (June 2020) shows only 5% of all connections are IPv6.
- * [NOTE] This is just an application level fallback. Disabling IPv6 is best done at an
+ * IPv6 can be abused, especially with MAC addresses, and can leak with VPNs: assuming
+ * your ISP and/or router and/or website is IPv6 capable. Most sites will fall back to IPv4
+ * [STATS] Firefox telemetry (July 2021) shows ~10% of all connections are IPv6
+ * [NOTE] This is an application level fallback. Disabling IPv6 is best done at an
  * OS/network level, and/or configured properly in VPN setups. If you are not masking your IP,
  * then this won't make much difference. If you are masking your IP, then it can only help.
+ * [NOTE] PHP defaults to IPv6 with "localhost". Use "php -S 127.0.0.1:PORT"
  * [TEST] https://ipleak.org/
- * [1] https://github.com/arkenfox/user.js/issues/437#issuecomment-403740626
- * [2] https://www.internetsociety.org/tag/ipv6-security/ (see Myths 2,4,5,6) ***/
+ * [1] https://www.internetsociety.org/tag/ipv6-security/ (Myths 2,4,5,6) ***/
 user_pref("network.dns.disableIPv6", true);
 user_pref("network.notify.IPv6", false);
-/* 0702: disable HTTP2
- * HTTP2 raises concerns with "multiplexing" and "server push", does nothing to
- * enhance privacy, and opens up a number of server-side fingerprinting opportunities.
- * [WARNING] Disabling this made sense in the past, and doesn't break anything, but HTTP2 is
- * at 40% (December 2019) and growing [5]. Don't be that one person using HTTP1.1 on HTTP2 sites
- * [1] https://http2.github.io/faq/
- * [2] https://blog.scottlogic.com/2014/11/07/http-2-a-quick-look.html
- * [3] https://http2.github.io/http2-spec/#rfc.section.10.8
- * [4] https://queue.acm.org/detail.cfm?id=2716278
- * [5] https://w3techs.com/technologies/details/ce-http2/all/all ***/
-   // user_pref("network.http.spdy.enabled", false);
-   // user_pref("network.http.spdy.enabled.deps", false);
-   // user_pref("network.http.spdy.enabled.http2", false);
-   // user_pref("network.http.spdy.websockets", false); // [FF65+]
-/* 0703: disable HTTP Alternative Services [FF37+]
- * [SETUP-PERF] Relax this if you have FPI enabled (see 4000) *AND* you understand the
- * consequences. FPI isolates these, but it was designed with the Tor protocol in mind,
- * and the Tor Browser has extra protection, including enhanced sanitizing per Identity.
- * [1] https://tools.ietf.org/html/rfc7838#section-9
- * [2] https://www.mnot.net/blog/2016/03/09/alt-svc ***/
-user_pref("network.http.altsvc.enabled", false);
-user_pref("network.http.altsvc.oe", false);
-/* 0704: enforce the proxy server to do any DNS lookups when using SOCKS
+/* 0702: set the proxy server to do any DNS lookups when using SOCKS
  * e.g. in Tor, this stops your local DNS server from knowing your Tor destination
  * as a remote Tor node will handle the DNS request
  * [1] https://trac.torproject.org/projects/tor/wiki/doc/TorifyHOWTO/WebBrowsers ***/
 user_pref("network.proxy.socks_remote_dns", true);
-/* 0708: disable FTP [FF60+]
- * [1] https://www.ghacks.net/2018/02/20/firefox-60-with-new-preference-to-disable-ftp/ ***/
-user_pref("network.ftp.enabled", false);
-/* 0709: disable using UNC (Uniform Naming Convention) paths [FF61+]
+/* 0703: disable using UNC (Uniform Naming Convention) paths [FF61+]
  * [SETUP-CHROME] Can break extensions for profiles on network shares
  * [1] https://gitlab.torproject.org/tpo/applications/tor-browser/-/issues/26424 ***/
 user_pref("network.file.disable_unc_paths", true); // [HIDDEN PREF]
-/* 0710: disable GIO as a potential proxy bypass vector
+/* 0704: disable GIO as a potential proxy bypass vector
  * Gvfs/GIO has a set of supported protocols like obex, network, archive, computer, dav, cdda,
  * gphoto2, trash, etc. By default only smb and sftp protocols are accepted so far (as of FF64)
  * [1] https://bugzilla.mozilla.org/1433507
@@ -394,17 +323,24 @@ user_pref("network.file.disable_unc_paths", true); // [HIDDEN PREF]
  * [3] https://en.wikipedia.org/wiki/GVfs
  * [4] https://en.wikipedia.org/wiki/GIO_(software) ***/
 user_pref("network.gio.supported-protocols", ""); // [HIDDEN PREF]
+/* 0705: disable DNS-over-HTTPS (DoH) rollout [FF60+]
+ * 0=off by default, 2=TRR (Trusted Recursive Resolver) first, 3=TRR only, 5=explicitly off
+ * see "doh-rollout.home-region": USA Feb 2020, Canada July 2021 [3]
+ * [1] https://hacks.mozilla.org/2018/05/a-cartoon-intro-to-dns-over-https/
+ * [2] https://wiki.mozilla.org/Security/DOH-resolver-policy
+ * [3] https://blog.mozilla.org/mozilla/news/firefox-by-default-dns-over-https-rollout-in-canada/
+ * [4] https://www.eff.org/deeplinks/2020/12/dns-doh-and-odoh-oh-my-year-review-2020 ***/
+   // user_pref("network.trr.mode", 5);
+/* 0706: disable proxy direct failover for system requests [FF91+] ***/
+user_pref("network.proxy.failover_direct", false);
 
-/*** [SECTION 0800]: HISTORY / FORMS
-     Consider your environment (no unwanted eyeballs), your device (restricted access),
-     your device's unattended state (locked, encrypted, forensic hardened).
-***/
+/*** [SECTION 0800]: LOCATION BAR / SEARCH BAR / SUGGESTIONS / HISTORY / FORMS ***/
 user_pref("_user.js.parrot", "0800 syntax error: the parrot's ceased to be!");
 /* 0801: disable location bar using search
- * Don't leak URL typos to a search engine, give an error message instead.
+ * Don't leak URL typos to a search engine, give an error message instead
  * Examples: "secretplace,com", "secretplace/com", "secretplace com", "secret place.com"
- * [NOTE] This does **not** affect explicit user action such as using search buttons in the
- * dropdown, or using keyword search shortcuts you configure in options (e.g. 'd' for DuckDuckGo)
+ * [NOTE] This does not affect explicit user action such as using search buttons in the
+ * dropdown, or using keyword search shortcuts you configure in options (e.g. "d" for DuckDuckGo)
  * [SETUP-CHROME] If you don't, or rarely, type URLs, or you use a default search
  * engine that respects privacy, then you probably don't need this ***/
 user_pref("keyword.enabled", false);  // [DEFAULT: false]
@@ -416,30 +352,39 @@ user_pref("keyword.enabled", false);  // [DEFAULT: false]
  * intend to), can leak sensitive data (e.g. query strings: e.g. Princeton attack),
  * and is a security risk (e.g. common typos & malicious sites set up to exploit this) ***/
 user_pref("browser.fixup.alternate.enabled", false);
-/* 0805: disable coloring of visited links - CSS history leak
- * [NOTE] This has NEVER been fully "resolved": in Mozilla/docs it is stated it's
- * only in 'certain circumstances', also see latest comments in [2]
- * [TEST] https://earthlng.github.io/testpages/visited_links.html (see github wiki APPENDIX A on how to use)
- * [1] https://dbaron.org/mozilla/visited-privacy
- * [2] https://bugzilla.mozilla.org/147777
- * [3] https://developer.mozilla.org/docs/Web/CSS/Privacy_and_the_:visited_selector ***/
-user_pref("layout.css.visited_links_enabled", false);
-/* 0807: disable live search suggestions
-/* [NOTE] Both must be true for the location bar to work
+/* 0804: disable live search suggestions
+ * [NOTE] Both must be true for the location bar to work
  * [SETUP-CHROME] Change these if you trust and use a privacy respecting search engine
  * [SETTING] Search>Provide search suggestions | Show search suggestions in address bar results ***/
 user_pref("browser.search.suggest.enabled", false);
-/* 0860: disable search and form history
- * [SETUP-WEB] Be aware thet autocomplete form data can be read by third parties, see [1] [2]
- * [NOTE] We also clear formdata on exit (see 2803)
+/* 0808: disable search and form history
+ * [SETUP-WEB] Be aware that autocomplete form data can be read by third parties [1][2]
+ * [NOTE] We also clear formdata on exit (2803)
  * [SETTING] Privacy & Security>History>Custom Settings>Remember search and form history
  * [1] https://blog.mindedsecurity.com/2011/10/autocompleteagain.html
  * [2] https://bugzilla.mozilla.org/381681 ***/
 user_pref("browser.formfill.enable", false);
-/* 0862: disable browsing and download history
- * [NOTE] We also clear history and downloads on exiting Firefox (see 2803)
- * [SETTING] Privacy & Security>History>Custom Settings>Remember browsing and download history ***/
-user_pref("places.history.enabled", false);
+/* 0809: disable Form Autofill
+ * [NOTE] Stored data is NOT secure (uses a JSON file)
+ * [NOTE] Heuristics controls Form Autofill on forms without @autocomplete attributes
+ * [SETTING] Privacy & Security>Forms and Autofill>Autofill addresses
+ * [1] https://wiki.mozilla.org/Firefox/Features/Form_Autofill ***/
+user_pref("extensions.formautofill.addresses.enabled", false); // [FF55+]
+user_pref("extensions.formautofill.available", "off"); // [FF56+]
+user_pref("extensions.formautofill.creditCards.available", false); // [FF57+]
+user_pref("extensions.formautofill.creditCards.enabled", false); // [FF56+]
+user_pref("extensions.formautofill.heuristics.enabled", false); // [FF55+]
+/* 0810: disable coloring of visited links
+ * Bulk rapid history sniffing was mitigated in 2010 [1][2]. Slower and more expensive
+ * redraw timing attacks were largely mitigated in FF77+ [3]. Using RFP (4501) further hampers timing
+ * attacks. Don't forget clearing history on close (2803). However, social engineering [2#limits][4][5]
+ * and advanced targeted timing attacks could still produce usable results
+ * [1] https://developer.mozilla.org/docs/Web/CSS/Privacy_and_the_:visited_selector
+ * [2] https://dbaron.org/mozilla/visited-privacy
+ * [3] https://bugzilla.mozilla.org/1632765
+ * [4] https://earthlng.github.io/testpages/visited_links.html (see github wiki APPENDIX A on how to use)
+ * [5] https://lcamtuf.blogspot.com/2016/08/css-mix-blend-mode-is-bad-for-keeping.html ***/
+user_pref("layout.css.visited_links_enabled", false);
 
 /*** [SECTION 1000]: CACHE / FAVICONS
      Cache tracking/fingerprinting techniques [1][2][3] require a cache. Disabling disk (1001)
@@ -1402,9 +1347,9 @@ user_pref("_user.js.parrot", "4700 syntax error: the parrot's taken 'is last bow
 /* 4707: Limit user-agent data by imitating Firefox's user-agent */
    // user_pref("general.useragent.compatMode.firefox", true);
 
-/*** [SECTION 5000]: PERSONAL
+/*** [SECTION 9000]: PERSONAL
      Non-project related but useful. If any of these interest you, add them to your overrides ***/
-user_pref("_user.js.parrot", "5000 syntax error: this is an ex-parrot!");
+user_pref("_user.js.parrot", "9000 syntax error: this is an ex-parrot!");
 /* WELCOME & WHAT's NEW NOTICES ***/
    //user_pref("mailnews.start_page_override.mstone", "ignore"); // master switch
 /* WARNINGS ***/
@@ -1431,16 +1376,16 @@ user_pref("mail.identity.id1.headers", "");
 user_pref("mail.identity.id1.header.References", "");
 user_pref("mail.identity.id1.header.InReplyTo", "");
 
-/*** [SECTION 6000]: THUNDERBIRD (AUTO CONFIG / UI / HEADERS / ADDRESS BOOK)
+/*** [SECTION 9100]: THUNDERBIRD (AUTO CONFIG / UI / HEADERS / ADDRESS BOOK)
    Options general to Thunderbird's mail configuration and user interface
 
-   [1] https://searchfox.org/comm-esr78/source/
+   [1] https://searchfox.org/comm-esr91/source/
    [2] http://kb.mozillazine.org/Mail_and_news_settings
 ***/
-user_pref("_user.js.parrot", "6000 syntax error: this parrot is blind!");
+user_pref("_user.js.parrot", "9100 syntax error: this parrot is blind!");
 
 /** AUTO CONFIG ***/
-/* 6001: Disable auto-configuration [SETUP-INSTALL]
+/* 9101: Disable auto-configuration [SETUP-INSTALL]
  * These options disable auto-configuration of mail servers in Thunderbird.
  * Such settings require a query to Mozilla which could have privacy implications
  * if the user wishes to keep the existence of the mail provider private.
@@ -1451,28 +1396,28 @@ user_pref("mailnews.auto_config.fetchFromISP.sendEmailAddress", false);
 user_pref("mailnews.auto_config.fetchFromExchange.enabled", false);
 user_pref("mailnews.auto_config_url", "");
 user_pref("mailnews.auto_config.addons_url","");
-/* 6002: Disable account provisioning [SETUP-INSTALL]
+/* 9102: Disable account provisioning [SETUP-INSTALL]
  * This option allows users to create a new email account through partner providers.
  * [1] https://developer.mozilla.org/en-US/docs/Mozilla/Thunderbird/Account_Provisioner ***/
 user_pref("mail.provider.enabled", false);
 
 /** UI (User Interface) ***/
-/* 6010: Hide tab bar
+/* 9110: Hide tab bar
  * false=Hides the tab bar if there is only one tab. (default) ***/
 user_pref("mail.tabs.autoHide", true);
-/* 6011: Show full email instead of just name from address book
+/* 9111: Show full email instead of just name from address book
  * true=Show just the display name for people in the address book (default)
  * false=Show both the email address and display name. ***/
 user_pref("mail.showCondensedAddresses", false);
-/* 6012: Disable "Filelink for Large Attachments" feature
+/* 9112: Disable "Filelink for Large Attachments" feature
  * [1] https://support.thunderbird.net/kb/filelink-large-attachments ***/
 user_pref("mail.cloud_files.enabled", false);
 user_pref("mail.cloud_files.inserted_urls.footer.link", "");
-/* 6013: Don't hide cookies and passwords related (advanced?) buttons ***/
+/* 9113: Don't hide cookies and passwords related (advanced?) buttons ***/
 user_pref("pref.privacy.disable_button.view_cookies", false);
 user_pref("pref.privacy.disable_button.cookie_exceptions", false);
 user_pref("pref.privacy.disable_button.view_passwords", false);
-/* 6014: Prevent access to emails until the master password is entered
+/* 9114: Prevent access to emails until the master password is entered
  * If a master password has been set, Thunderbird will prevent access to locally available emails
  * until the secret is provided.
  * This preference MAY mitigate risk due to intimate relationship threat in some cases (see [2])...
@@ -1482,22 +1427,22 @@ user_pref("pref.privacy.disable_button.view_passwords", false);
 user_pref("mail.password_protect_local_cache", true);  // [HIDDEN PREF]
 
 /** HEADERS ***/
-/* 6020:
+/* 9120:
  * true=Show Sender header in message pane.
  * false=Does nothing. (default) ***/
 user_pref("mailnews.headers.showSender", true);
-/* 6021:
+/* 9121:
  * true=Show User Agent header in message pane
  * false=Does nothing. (default) ***/
 user_pref("mailnews.headers.showUserAgent", false);
-/* 6022: Hello argument
+/* 9122: Hello argument
  * Lets you replace your IP address with the specified string in Received: headers when your
  * IP address is not a "fully qualified domain name" (FQDN). Typically you only need to do this
  * when you have a NAT box to prevent it from using the NAT boxes IP address.
  * If you don't set it to something in your SMTP server's domain it may increase your spam
  * score. ***/
 user_pref("mail.smtpserver.default.hello_argument", "[127.0.0.1]");
-/* 6023: Displayed dates and times
+/* 9123: Displayed dates and times
  * [SETUP-INSTALL] When your e-mail program displays the e-mail's date and time, it normally
  * converts them to your time zone. If your computer's time zone settings are wrong, then you will
  * see the wrong time (and possibly the wrong date).
@@ -1508,9 +1453,9 @@ user_pref("mail.smtpserver.default.hello_argument", "[127.0.0.1]");
  * [2] http://wiki.cacert.org/ThunderBirdAdvancedConfig
  * ***/
 user_pref("mailnews.display.original_date", false);
-/* 6024: Display the sender's Timezone when set to true ***/
+/* 9124: Display the sender's Timezone when set to true ***/
 user_pref("mailnews.display.date_senders_timezone", false);
-/* 6025: Display Time Date based on Received Header
+/* 9125: Display Time Date based on Received Header
  * Thunderbird shows the time when the message was sent, according to the sender. It is possible
  * to make Thunderbird show the time when the message arrived on your mail server, based on the
  * "Received" header. Set the following preference. New messages will show the time the message
@@ -1518,40 +1463,40 @@ user_pref("mailnews.display.date_senders_timezone", false);
    // user_pref("mailnews.use_received_date", true);
 
 /** ADDRESS BOOK ***/
-/* 6030: Address book collection [SETUP-FEATURE]
+/* 9130: Address book collection [SETUP-FEATURE]
  * Disable Thunderbird internal address book email collection
  * Consider using CardBook extension instead (https://addons.thunderbird.net/addon/cardbook/)
  * [SETTING] Preferences>Composition>Addressing>Automatically add outgoing e-mail addresses...
  * [SETTING][CARDBOOK] CardBook>Preferences>Email>Collect Outgoing Email ***/
 user_pref("mail.collect_addressbook", "");  // [DEFAULT: "jsaddrbook://history.sqlite"]
 user_pref("mail.collect_email_address_outgoing", false);
-/* 6031: Only use email addresses, without their Display Names [CARDBOOK] [SETUP-FEATURE]
+/* 9131: Only use email addresses, without their Display Names [CARDBOOK] [SETUP-FEATURE]
  * By default, CardBook extension incorporates contacts display names in addresses fields.
  * This could leak sensitive information to all recipients.
  * [SETTING][CARDBOOK] CardBook>Preferences>Email>Sending Emails>Only use email addresses... ***/
 user_pref("extensions.cardbook.useOnlyEmail", true);
 
-/*** [SECTION 6100]: EMAIL COMPOSITION (ENCODING / FORMAT / VIEW)
+/*** [SECTION 9200]: EMAIL COMPOSITION (ENCODING / FORMAT / VIEW)
    Options that relate to composition, formatting and viewing email
 ***/
-user_pref("_user.js.parrot", "6100 syntax error: this parrot has got no mail!");
+user_pref("_user.js.parrot", "9200 syntax error: this parrot has got no mail!");
 
 /** ENCODING ***/
-/* 6101: Prevent fallback encoding to windows-1252, prefer 7bit or 8bit UTF-8
+/* 9201: Prevent fallback encoding to windows-1252, prefer 7bit or 8bit UTF-8
  * [1] http://forums.mozillazine.org/viewtopic.php?f=28&t=267341
  * [2] https://bugzilla.mozilla.org/show_bug.cgi?id=214729
  * [3] https://stackoverflow.com/a/28531705 ***/
 user_pref("intl.fallbackCharsetList.ISO-8859-1", "UTF-8");
-/* 6102: Set encoding of incoming mail
+/* 9202: Set encoding of incoming mail
  * [SETTING] Display > Advanced > Fonts & Encodings > Incoming Mail ***/
 user_pref("mailnews.view_default_charset", "UTF-8");
-/* 6103: Set encoding of outgoing mail
+/* 9203: Set encoding of outgoing mail
  * [SETTING] Display > Advanced > Fonts & Encodings > Outgoing Mail ***/
 user_pref("mailnews.send_default_charset", "UTF-8");
-/* 6104: Forces encoding in reply to be the default charset
+/* 9204: Forces encoding in reply to be the default charset
  * [1] https://bugzilla.mozilla.org/show_bug.cgi?id=234958#c2 ***/
 user_pref("mailnews.reply_in_default_charset", true);
-/* 6105: Avoid information leakage in reply header
+/* 9205: Avoid information leakage in reply header
  * Reply header may contain sensitive information about system locale (date and/or language)
  * 0=no header
  * 1="<author> wrote:" (see `reply_header_authorwrotesingle` below)
@@ -1564,17 +1509,17 @@ user_pref("mailnews.reply_header_authorwrotesingle", "#1 wrote:");
    // user_pref("mailnews.reply_header_authorwroteondate", "#1 wrote on #2 #3:");
 
 /** COMPOSITION ***/
-/* 6110: Check spelling before sending [SETUP-FEATURE]
+/* 9210: Check spelling before sending [SETUP-FEATURE]
  * [1] https://bugzilla.mozilla.org/show_bug.cgi?id=667133 ***/
 user_pref("mail.SpellCheckBeforeSend", false);
-/* 6111: Behavior when sending HTML message [SETUP-FEATURE]
+/* 9211: Behavior when sending HTML message [SETUP-FEATURE]
  * (0=Ask, 1=Send as plain text, 2=Send as HTML anyway,
  * 3=Include both plain text and HTML message bodies in message)
  * Email that is HTML should also have plaintext multipart for plain text users.
  * [1] https://drewdevault.com/2016/04/11/Please-use-text-plain-for-emails.html
  * [SETTING] Edit > Preferences > Send Options > Send the message in both plain text and HTML ***/
 user_pref("mail.default_html_action", 1);
-/* 6112: Send email in plaintext unless expressly overridden.
+/* 9212: Send email in plaintext unless expressly overridden.
  * [SETUP-FEATURE] Sometimes HTML is useful especially when used with Markdown Here
  * [NOTE] Holding down shift when you click on "Write" will bypass
  * [1] http://kb.mozillazine.org/Plain_text_e-mail_%28Thunderbird%29
@@ -1582,18 +1527,18 @@ user_pref("mail.default_html_action", 1);
  * [3] https://markdown-here.com ***/
 user_pref("mail.html_compose", false);
 user_pref("mail.identity.default.compose_html", false);
-/* 6113: Downgrade email to plaintext by default
+/* 9213: Downgrade email to plaintext by default
  * [SETUP-FEATURE] Only use HTML email if you need it, see above
  * [SETTING] Edit > Preferences > Composition > Send Options > Send messages as plain-text if possible ***/
 user_pref("mailnews.sendformat.auto_downgrade", false);
-/* 6114: What classes can process incoming data.
+/* 9214: What classes can process incoming data.
  * (0=All classes (default), 1=Don't display HTML, 2=Don't display HTML and inline images,
  * 3=Don't display HTML, inline images and some other uncommon types, 100=Use a hard coded list)
  * In the past this has mitigated a vulnerability CVE-2008-0304 (rare)
  * [1] https://www.mozilla.org/en-US/security/advisories/mfsa2008-12/
  * [2] https://bugzilla.mozilla.org/show_bug.cgi?id=677905 ***/
 user_pref("mailnews.display.disallow_mime_handlers", 3);
-/* 6115: How to display HTML parts of a message body
+/* 9215: How to display HTML parts of a message body
  * (0=Display the HTML normally (default), 1=Convert it to text and then back again
  * 2=Display the HTML source, 3=Sanitize the HTML, 4=Display all body parts)
  * (in trunk builds later than 2011-07-23)
@@ -1601,67 +1546,67 @@ user_pref("mailnews.display.disallow_mime_handlers", 3);
  * [2] https://hg.mozilla.org/comm-central/rev/c1ef44a22eb2
  * [3] https://www.bucksch.org/1/projects/mozilla/108153/ ***/
 user_pref("mailnews.display.html_as", 3);
-/* 6116: Prefer to view as plaintext or html [SETUP-FEATURE]
+/* 9216: Prefer to view as plaintext or html [SETUP-FEATURE]
  * true=Display a message as plain text when there is both a HTML and a plain
  * text version of a message body
  * false=Display a message as HTML when there is both a HTML and a plain text
  * version of a message body. (default) ***/
 user_pref("mailnews.display.prefer_plaintext", false);
-/* 6117: Inline attachments [SETUP-FEATURE]
+/* 9217: Inline attachments [SETUP-FEATURE]
  * true=Show inlinable attachments (text, images, messages) after the message.
  * false=Do not display any attachments with the message ***/
 user_pref("mail.inline_attachments", false);
-/* 6118: Big attachment warning
+/* 9218: Big attachment warning
  * [1] https://support.mozilla.org/en-US/questions/1081046
  * [2] http://forums.mozillazine.org/viewtopic.php?f=39&t=2949521 */
 user_pref("mail.compose.big_attachments.notify", true); // [DEFAULT: true]
-/* 6119: Set big attachment size to warn at */
+/* 9219: Set big attachment size to warn at */
    // user_pref("mailnews.message_warning_size", 20971520); // [DEFAULT: 20971520]
 
 /** VIEW ***/
-/* 6130: Disable JavaScript
+/* 9230: Disable JavaScript
  * [NOTE] JavaScript is already disabled in message content.
  * [1] https://developer.mozilla.org/en-US/docs/Mozilla/Thunderbird/Releases/3
  * [2] https://stackoverflow.com/questions/3054315/is-javascript-supported-in-an-email-message
  * ***/
 user_pref("javascript.enabled", false);
-/* 6131: Disable media source extensions
+/* 9231: Disable media source extensions
  * [1] https://www.ghacks.net/2014/05/10/enable-media-source-extensions-firefox ***/
 user_pref("media.mediasource.enabled", false);
-/* 6132: Disable hardware decoding support ***/
+/* 9232: Disable hardware decoding support ***/
 user_pref("media.hardware-video-decoding.enabled", false);
-/* 6133: Default image permissions
+/* 9233: Default image permissions
  * 1=Allow all images to load, regardless of origin. (Default),
  * 2=Block all images from loading.
  * 3=Prevent third-party images from loading
  * [1] http://kb.mozillazine.org/Permissions.default.image ***/
 user_pref("permissions.default.image", 2);
 
-/*** [SECTION 6200]: OTHER THUNDERBIRD COMPONENTS (CHAT / CALENDAR / RSS)
+/*** [SECTION 9300]: OTHER THUNDERBIRD COMPONENTS (CHAT / CALENDAR / RSS)
    Options that relate to other Thunderbird components such as the chat client, calendar and RSS)
 ***/
-user_pref("_user.js.parrot", "6200 syntax error: this parrot is not tweeting!");
+user_pref("_user.js.parrot", "9300 syntax error: this parrot is not tweeting!");
 
 /** CHAT ***/
-/* 6201: Disable chat functionality [SETUP-FEATURE] ***/
+/* 9301: Disable chat functionality [SETUP-FEATURE] ***/
 user_pref("mail.chat.enabled", false);
-/* 6202: Disable logging of group chats ***/
+/* 9302: Disable logging of group chats ***/
 user_pref("purple.logging.log_chats", false);
-/* 6203: Disable logging of 1 to 1 conversations ***/
+/* 9303: Disable logging of 1 to 1 conversations ***/
 user_pref("purple.logging.log_ims", false);
-/* 6204: Disable logging of system messages ***/
+/* 9304: Disable logging of system messages ***/
 user_pref("purple.logging.log_system", false);
-/* 6205: Disable typing notifications ***/
+/* 9305: Disable typing notifications ***/
 user_pref("purple.conversations.im.send_typing", false);
-/* 6206: When chat is enabled, do not connect to accounts automatically
+/* 9306: When chat is enabled, do not connect to accounts automatically
  * 0=Do not connect / show the account manager,
  * 1=Connect automatically. (Default) ***/
    // user_pref("messenger.startup.action", 0);
-/* 6207: When chat is enabled, do not report idle status ***/
+/* 9307: When chat is enabled, do not report idle status ***/
    // user_pref("messenger.status.reportIdle", false);
 
 /** CALENDAR ***/
-/* 6210: Disable calendar integration
+/* 9310: Disable calendar integration
  * [SETUP-FEATURE] Lightning calendar add-on is integrated in Thunderbird 38 and later.
  * Keeping this preference false allows us to properly show the opt-in/opt-out dialog
  * on new profiles fresh start, see [3].
@@ -1669,9 +1614,9 @@ user_pref("purple.conversations.im.send_typing", false);
  * [2] https://bugzilla.mozilla.org/show_bug.cgi?id=1130854
  * [3] https://bugzilla.mozilla.org/show_bug.cgi?id=1130852 ***/
 user_pref("mail.calendar-integration.opt-out", false);
-/* 6211: Set user agent for calendar ***/
+/* 9311: Set user agent for calendar ***/
 user_pref("calendar.useragent.extra", "");
-/* 6212: Set calendar timezone to avoid system detection [SETUP-INSTALL]
+/* 9312: Set calendar timezone to avoid system detection [SETUP-INSTALL]
  * By default, extensive system detection would be performed to find user's current timezone.
  * Setting this preference to "UTC" should disable it.
  * You may also directly set it to your timezone, i.e. "Pacific/Fakaofo"
@@ -1682,12 +1627,12 @@ user_pref("calendar.timezone.local", "UTC");  // [DEFAULT: ""]
 /** These features don't actually do anything as they aren't implemented
  * [1] https://searchfox.org/comm-esr78/rev/384830b0570096c48770398060f87fbe556f6f01/mail/base/content/mailWindowOverlay.js#925
  * [2] https://bugzilla.mozilla.org/show_bug.cgi?id=458606#c9
-/* 6220: What classes can process incoming data.
+/* 9320: What classes can process incoming data.
  * (0=All classes (default), 1=Don't display HTML, 2=Don't display HTML and inline images,
  * 3=Don't display HTML, inline images and some other uncommon types, 100=Use a hard coded list)
  * [1] https://www.privacy-handbuch.de/handbuch_31j.htm
 user_pref("rss.display.disallow_mime_handlers", 3);
-/* 6221: How to display HTML parts of a message body
+/* 9321: How to display HTML parts of a message body
  * (0=Display the HTML normally (default), 1=Convert it to text and then back again
  * 2=Display the HTML source, 3=Sanitize the HTML, 4=Display all body parts)
  * (in trunk builds later than 2011-07-23)
@@ -1695,47 +1640,47 @@ user_pref("rss.display.disallow_mime_handlers", 3);
  * [2] https://hg.mozilla.org/comm-central/rev/c1ef44a22eb2
  * [3] https://www.bucksch.org/1/projects/mozilla/108153/
 user_pref("rss.display.html_as", 1);
-/* 6222: Prefer to view as plaintext or html
+/* 9322: Prefer to view as plaintext or html
  * true=Display a message as plain text when there is both a HTML and a plain
  * text version of a message body
  * false=Display a message as HTML when there is both a HTML and a plain text
  * version of a message body. (default)
 user_pref("rss.display.prefer_plaintext", true);
 **/
-/* 6223: Feed message display (summary or web page), on open.
+/* 9323: Feed message display (summary or web page), on open.
  * Action on double click or enter in threadpane for a feed message.
  * 0=open content-base url in new window, 1=open summary in new window,
  * 2=toggle load summary and content-base url in message pane,
  * 3=load content-base url in browser
  * [1] http://forums.mozillazine.org/viewtopic.php?f=39&t=2502335 ***/
 user_pref("rss.show.content-base", 3);
-/* 6224: Feed message display (summary or web page), on select.
+/* 9324: Feed message display (summary or web page), on select.
  * 0=global override, load web page, 1=global override, load summary,
  * 2=use default feed folder setting from Subscribe dialog; if no setting default to 1 ***/
 user_pref("rss.show.summary", 1);
-/* 6225: Feed message additional web page display.
+/* 9325: Feed message additional web page display.
  * 0=no action, 1=load web page in default browser, on select ***/
 user_pref("rss.message.loadWebPageOnSelect", 0);
 
-/*** [SECTION 6300]: THUNDERBIRD ENCRYPTION (ENIGMAIL / AUTOCRYPT / GNUPG)
+/*** [SECTION 9400]: THUNDERBIRD ENCRYPTION (ENIGMAIL / AUTOCRYPT / GNUPG)
    Options that relate to Enigmail addon and AutoCrypt.
    GnuPG (and RNP) specific options should also land there.
    [1] https://autocrypt.org
    [2] https://www.enigmail.net/index.php/en/user-manual/advanced-operations
    [3] https://wiki.mozilla.org/Thunderbird:OpenPGP
 ***/
-user_pref("_user.js.parrot", "6300 syntax error: this parrot is talking in codes!");
+user_pref("_user.js.parrot", "9400 syntax error: this parrot is talking in codes!");
 
 /** ENIGMAIL ***/
 /* These used to be inversed, however it seems upstream has changed this behavior
  * [1] https://www.privacy-handbuch.de/handbuch_31f.htm ***/
-/* 6301: Silence the Enigmail version header ***/
+/* 9401: Silence the Enigmail version header ***/
 user_pref("extensions.enigmail.addHeaders", false); // [DEFAULT: false]
-/* 6302: Silence the Enigmail comment ***/
+/* 9402: Silence the Enigmail comment ***/
 user_pref("extensions.enigmail.useDefaultComment", true); // [DEFAULT: true]
-/* 6303: Silence the version ***/
+/* 9403: Silence the version ***/
 user_pref("extensions.enigmail.agentAdditionalParam", "--no-emit-version --no-comments");
-/* 6304: Specifies the hash algorithm used by GnuPG for its cryptographic operations:
+/* 9404: Specifies the hash algorithm used by GnuPG for its cryptographic operations:
  * 0=automatic selection, let GnuPG choose (default, recommended), 1=SHA1, 2=RIPEMD160
  * 3=SHA256, 4=SHA384, 5=SHA512
  * [NOTE] You should probably have a decent gpg.conf with things set. Examples
@@ -1743,31 +1688,31 @@ user_pref("extensions.enigmail.agentAdditionalParam", "--no-emit-version --no-co
  * [2] https://github.com/ioerror/torbirdy/blob/master/gpg.conf
  * ***/
 user_pref("extensions.enigmail.mimeHashAlgorithm", 5);
-/* 6305: Protect subject line
+/* 9405: Protect subject line
  * 0=Leave subject unprotected,
  * 1=Show dialog with "Leave subject unprotected" (changes value to 0)
  *                     or "Protect subject" (changes value to 2,
  * 2=Protect subject***/
 user_pref("extensions.enigmail.protectedHeaders", 2);
-/* 6306: Text to use as replacement for the subject, following the Memory Hole
+/* 9406: Text to use as replacement for the subject, following the Memory Hole
  * standard. If nothing is defined, then "Encrypted Message" is used.
  ***/
 user_pref("extensions.enigmail.protectedSubjectText", "Encrypted Message"); // [DEFAULT: "Encrypted Message"]
 
 /** AUTOCRYPT ***/
-/* 6307: Choose whether to enable AutoCrypt
+/* 9407: Choose whether to enable AutoCrypt
  * [1] https://autocrypt.org/level1.html
  * [2] https://redmine.tails.boum.org/code/issues/16186
  * [SETTING] Edit > Account Settings > OpenPGP Security > Autocrypt > Enable Autocrypt ***/
 user_pref("mail.server.default.enableAutocrypt", false);
-/* 6308: Prefer email encryption with known contacts
+/* 9408: Prefer email encryption with known contacts
  * [SETTING] Edit > Account Settings > OpenPGP Security > Autocrypt >
  *           Prefer encrypted emails from the people you exchange email with
  *  [1] https://redmine.tails.boum.org/code/issues/15923 ***/
 user_pref("mail.server.default.acPreferEncrypt", 0);
 
 /** GNUPG ***/
-/* 6309: Allow the use of external GnuPG
+/* 9409: Allow the use of external GnuPG
  * Whenever RNP fails to decrypt a message, Thunderbird will tray against system GnuPG
  * [1] https://wiki.mozilla.org/Thunderbird:OpenPGP:Smartcards#Allow_the_use_of_external_GnuPG ***/
 user_pref("mail.openpgp.allow_external_gnupg", true);  // [HIDDEN PREF]

--- a/user.js
+++ b/user.js
@@ -519,6 +519,10 @@ user_pref("security.cert_pinning.enforcement_level", 2);
  * [2] https://blog.mozilla.org/security/tag/crlite/ ***/
 user_pref("security.remote_settings.crlite_filters.enabled", true);
 user_pref("security.pki.crlite_mode", 2);
+/* 1225: enable loading of client certificates stored in OS certificate storage
+  * Bug: this does **NOT** work for S/MIME [1]
+  * [1] https://bugzilla.mozilla.org/show_bug.cgi?id=1726442 ***/
+   // user_pref("security.osclientcerts.autoload", true);
 
 /** MIXED CONTENT ***/
 /* 1241: disable insecure passive content (such as images) on https pages [SETUP-WEB] ***/

--- a/user.js
+++ b/user.js
@@ -231,6 +231,9 @@ user_pref("mail.instrumentation.userOptedIn", false);
  * [1] https://searchfox.org/comm-esr78/rev/384830b0570096c48770398060f87fbe556f6f01/mail/base/content/specialTabs.js#1218 ***/
 user_pref("mail.rights.override", true);  // [DEFAULT: unset]
    // user_pref("mail.rights.version", 1)  // [DEFAULT: unset]
+/* 0380: disable the unread message count badge on taskbar icon
+ * [1] https://www.thunderbird.net/en-US/thunderbird/91.0.2/releasenotes/#whatsnew */
+  // user_pref("mail.biff.show_badge", false); // [WINDOWS]
 
 /*** [SECTION 0400]: SAFE BROWSING (SB)
    SB has taken many steps to preserve privacy. If required, a full url is never sent

--- a/user.js
+++ b/user.js
@@ -60,7 +60,7 @@
   9100: THUNDERBIRD (AUTO CONFIG / UI / HEADERS / ADDRESS BOOK)
   9200: EMAIL COMPOSITION (ENCODING / FORMAT / VIEW)
   9300: OTHER THUNDERBIRD COMPONENTS (CHAT / CALENDAR / RSS)
-  9400: THUNDERBIRD ENCRYPTION (ENIGMAIL / AUTOCRYPT / GNUPG)
+  9400: THUNDERBIRD ENCRYPTION (OPENGPG / GNUPG)
   9999: DEPRECATED / REMOVED / LEGACY / RENAMED
 
 ******/
@@ -1585,54 +1585,12 @@ user_pref("rss.show.summary", 1);
  * 0=no action, 1=load web page in default browser, on select ***/
 user_pref("rss.message.loadWebPageOnSelect", 0);
 
-/*** [SECTION 9400]: THUNDERBIRD ENCRYPTION (ENIGMAIL / AUTOCRYPT / GNUPG)
-   Options that relate to Enigmail addon and AutoCrypt.
-   GnuPG (and RNP) specific options should also land there.
-   [1] https://autocrypt.org
-   [2] https://www.enigmail.net/index.php/en/user-manual/advanced-operations
-   [3] https://wiki.mozilla.org/Thunderbird:OpenPGP
+/*** [SECTION 9400]: THUNDERBIRD ENCRYPTION (OPENGPG / GNUPG)
+   Options that relate to e-mail encryption in Thunderbird.
+   [1] https://wiki.mozilla.org/Thunderbird:OpenPGP
+   [2] https://support.mozilla.org/kb/openpgp-thunderbird-howto-and-faq
 ***/
 user_pref("_user.js.parrot", "9400 syntax error: this parrot is talking in codes!");
-
-/** ENIGMAIL ***/
-/* These used to be inversed, however it seems upstream has changed this behavior
- * [1] https://www.privacy-handbuch.de/handbuch_31f.htm ***/
-/* 9401: Silence the Enigmail version header ***/
-user_pref("extensions.enigmail.addHeaders", false); // [DEFAULT: false]
-/* 9402: Silence the Enigmail comment ***/
-user_pref("extensions.enigmail.useDefaultComment", true); // [DEFAULT: true]
-/* 9403: Silence the version ***/
-user_pref("extensions.enigmail.agentAdditionalParam", "--no-emit-version --no-comments");
-/* 9404: Specifies the hash algorithm used by GnuPG for its cryptographic operations:
- * 0=automatic selection, let GnuPG choose (default, recommended), 1=SHA1, 2=RIPEMD160
- * 3=SHA256, 4=SHA384, 5=SHA512
- * [NOTE] You should probably have a decent gpg.conf with things set. Examples
- * [1] https://github.com/Whonix/anon-gpg-tweaks/blob/master/etc/skel/.gnupg/gpg.conf
- * [2] https://github.com/ioerror/torbirdy/blob/master/gpg.conf
- * ***/
-user_pref("extensions.enigmail.mimeHashAlgorithm", 5);
-/* 9405: Protect subject line
- * 0=Leave subject unprotected,
- * 1=Show dialog with "Leave subject unprotected" (changes value to 0)
- *                     or "Protect subject" (changes value to 2,
- * 2=Protect subject***/
-user_pref("extensions.enigmail.protectedHeaders", 2);
-/* 9406: Text to use as replacement for the subject, following the Memory Hole
- * standard. If nothing is defined, then "Encrypted Message" is used.
- ***/
-user_pref("extensions.enigmail.protectedSubjectText", "Encrypted Message"); // [DEFAULT: "Encrypted Message"]
-
-/** AUTOCRYPT ***/
-/* 9407: Choose whether to enable AutoCrypt
- * [1] https://autocrypt.org/level1.html
- * [2] https://redmine.tails.boum.org/code/issues/16186
- * [SETTING] Edit > Account Settings > OpenPGP Security > Autocrypt > Enable Autocrypt ***/
-user_pref("mail.server.default.enableAutocrypt", false);
-/* 9408: Prefer email encryption with known contacts
- * [SETTING] Edit > Account Settings > OpenPGP Security > Autocrypt >
- *           Prefer encrypted emails from the people you exchange email with
- *  [1] https://redmine.tails.boum.org/code/issues/15923 ***/
-user_pref("mail.server.default.acPreferEncrypt", 0);
 
 /** GNUPG ***/
 /* 9409: Allow the use of external GnuPG

--- a/user.js
+++ b/user.js
@@ -422,9 +422,10 @@ user_pref("network.http.windows-sso.enabled", false); // [DEFAULT: false]
  * until the secret is provided.
  * This preference MAY mitigate risk due to intimate relationship threat in some cases (see [2])...
  * [WARNING] This DOES NOT encrypt locally cached emails anyhow (poor man's application security)
+ * [WARNING] This preference is very buggy, you might not manage to start Thunderbird when it's switched on
  * [1] https://support.mozilla.org/en-US/kb/protect-your-thunderbird-passwords-master-password
  * [2] https://www.schneier.com/wp-content/uploads/2020/06/Privacy_Threats_in_Intimate_Relationships-1.pdf ***/
-user_pref("mail.password_protect_local_cache", true);  // [HIDDEN PREF]
+  // user_pref("mail.password_protect_local_cache", true);  // [HIDDEN PREF]
 
 /*** [SECTION 1000]: DISK AVOIDANCE ***/
 user_pref("_user.js.parrot", "1000 syntax error: the parrot's gone to meet 'is maker!");

--- a/user.js
+++ b/user.js
@@ -1118,7 +1118,7 @@ user_pref("javascript.options.jit_trustedprincipals", true); // [FF75+] [HIDDEN 
  * Vulnerabilities [1] have increasingly been found, including those known and fixed
  * in native programs years ago [2]. WASM has powerful low-level access, making
  * certain attacks (brute-force) and vulnerabilities more possible
- * [STATS] ~0.2% of websites, about half of which are for crytopmining / malvertising [2][3]
+ * [STATS] ~0.2% of websites, about half of which are for crytomining / malvertising [2][3]
  * [1] https://cve.mitre.org/cgi-bin/cvekey.cgi?keyword=wasm
  * [2] https://spectrum.ieee.org/tech-talk/telecom/security/more-worries-over-the-security-of-web-assembly
  * [3] https://www.zdnet.com/article/half-of-the-websites-using-webassembly-use-it-for-malicious-purposes ***/
@@ -1259,7 +1259,6 @@ user_pref("_user.js.parrot", "8000 syntax error: the parrot's crossed the Jordan
    // user_pref("dom.webaudio.enabled", false);
 /* 8002: disable other ***/
    // user_pref("browser.display.use_document_fonts", 0);
-   // user_pref("browser.zoom.siteSpecific", false);
    // user_pref("dom.w3c_touch_events.enabled", 0);
    // user_pref("media.navigator.enabled", false);
    // user_pref("media.ondevicechange.enabled", false);
@@ -1278,27 +1277,29 @@ user_pref("_user.js.parrot", "8000 syntax error: the parrot's crossed the Jordan
    // user_pref("ui.use_standins_for_native_colors", true);
 
 /*** [SECTION 9000]: PERSONAL
-     Non-project related but useful. If any of these interest you, add them to your overrides ***/
-user_pref("_user.js.parrot", "9000 syntax error: this is an ex-parrot!");
-/* WELCOME & WHAT's NEW NOTICES ***/
-   //user_pref("mailnews.start_page_override.mstone", "ignore"); // master switch
+   Non-project related but useful. If any interest you, add them to your overrides
+***/
+user_pref("_user.js.parrot", "9000 syntax error: the parrot's cashed in 'is chips!");
+/* WELCOME & WHAT'S NEW NOTICES ***/
+user_pref("mailnews.start_page_override.mstone", "ignore"); // master switch
 /* WARNINGS ***/
    // user_pref("full-screen-api.warning.delay", 0);
    // user_pref("full-screen-api.warning.timeout", 0);
 /* APPEARANCE ***/
+   // user_pref("ui.systemUsesDarkTheme", 1); // [FF67+] [HIDDEN PREF]
+      // 0=light, 1=dark: with RFP this only affects chrome
    // user_pref("toolkit.legacyUserProfileCustomizations.stylesheets", true); // [FF68+] allow userChrome/userContent
+   // user_pref("ui.prefersReducedMotion", 1); // disable chrome animations [FF77+] [RESTART] [HIDDEN PREF]
+      // 0=no-preference, 1=reduce: with RFP this only affects chrome
 /* CONTENT BEHAVIOR ***/
    // user_pref("accessibility.typeaheadfind", true); // enable "Find As You Type"
    // user_pref("clipboard.autocopy", false); // disable autocopy default [LINUX]
-/* RETURN RECEIPT BEHAVIOR ***/
-   // user_pref("mail.mdn.report.enabled", false); // disable return receipt sending unconditionally
 /* UX BEHAVIOR ***/
    // user_pref("general.autoScroll", false); // middle-click enabling auto-scrolling [DEFAULT: false on Linux]
    // user_pref("ui.key.menuAccessKey", 0); // disable alt key toggling the menu bar [RESTART]
-/* OTHER ***/
-   // user_pref("network.manage-offline-status", false); // see bugzilla 620472
-   // user_pref("xpinstall.signatures.required", false); // enforced extension signing (Nightly/ESR)
-/* Set custom headers ***/
+/* RETURN RECEIPT BEHAVIOR ***/
+   // user_pref("mail.mdn.report.enabled", false); // disable return receipt sending unconditionally
+/* CUSTOM HEADERS ***/
    // user_pref("mail.identity.id1.headers", "References, InReplyTo");
    // user_pref("mail.identity.id1.header.References", "References: <2ad46d80-c8ce-49a3-9896-16171788ac28@example.tld>\n <31ff00c2-b7cb-4063-beeb-a0bdd424c3a7@example1.tld>");
    // user_pref("mail.identity.id1.header.InReplyTo", "In-Reply-To: <31ff00c2-b7cb-4063-beeb-a0bdd424c3a7@example1.tld>");
@@ -1640,93 +1641,57 @@ user_pref("mail.server.default.acPreferEncrypt", 0);
 user_pref("mail.openpgp.allow_external_gnupg", true);  // [HIDDEN PREF]
 
 /*** [SECTION 9999]: DEPRECATED / REMOVED / LEGACY / RENAMED
-     Documentation denoted as [-]. Items deprecated in FF68 or earlier have been archived at [1],
-     which also provides a link-clickable, viewer-friendly version of the deprecated bugzilla tickets
-     [1] https://github.com/ghacksuserjs/ghacks-user.js/issues/123
+   Documentation denoted as [-]. Items deprecated in FF78 or earlier have been archived at [1]
+   [1] https://github.com/arkenfox/user.js/issues/123
 ***/
 user_pref("_user.js.parrot", "9999 syntax error: the parrot's deprecated!");
-/* ESR68.x still uses all the following prefs
+/* ESR78.x still uses all the following prefs
 // [NOTE] replace the * with a slash in the line above to re-enable them
-// FF69
-// 1405: disable WOFF2 (Web Open Font Format) [FF35+]
-   // [-] https://bugzilla.mozilla.org/1556991
-   // user_pref("gfx.downloadable_fonts.woff2.enabled", false);
-// 1802: enforce click-to-play for plugins
-   // [-] https://bugzilla.mozilla.org/1519434
-user_pref("plugins.click_to_play", true); // [DEFAULT: true FF25+]
-// 2033: disable autoplay for muted videos [FF63+] - replaced by 'media.autoplay.default' options (2030)
-   // [-] https://bugzilla.mozilla.org/1562331
-   // user_pref("media.autoplay.allow-muted", false);
-// * * * /
-// FF71
-// 2608: disable WebIDE and ADB extension download
-   // [1] https://trac.torproject.org/projects/tor/ticket/16222
-   // [-] https://bugzilla.mozilla.org/1539462
-user_pref("devtools.webide.enabled", false); // [DEFAULT: false FF70+]
-user_pref("devtools.webide.autoinstallADBExtension", false); // [FF64+]
-// 2731: enforce websites to ask to store data for offline use
-   // [1] https://support.mozilla.org/questions/1098540
-   // [2] https://bugzilla.mozilla.org/959985
-   // [-] https://bugzilla.mozilla.org/1574480
-user_pref("offline-apps.allow_by_default", false);
-// * * * /
-// FF72
-// 0105a: disable Activity Stream telemetry
-   // [-] https://bugzilla.mozilla.org/1597697
-user_pref("browser.newtabpage.activity-stream.telemetry.ping.endpoint", "");
-// 0330: disable Hybdrid Content telemetry
-   // [-] https://bugzilla.mozilla.org/1520491
-user_pref("toolkit.telemetry.hybridContent.enabled", false); // [FF59+]
-// 2720: enforce IndexedDB (IDB) as enabled
-   // IDB is required for extensions and Firefox internals (even before FF63 in [1])
-   // To control *website* IDB data, control allowing cookies and service workers, or use
-   // Temporary Containers. To mitigate *website* IDB, FPI helps (4001), and/or sanitize
-   // on close (Offline Website Data, see 2800) or on-demand (Ctrl-Shift-Del), or automatically
-   // via an extension. Note that IDB currently cannot be sanitized by host.
-   // [1] https://blog.mozilla.org/addons/2018/08/03/new-backend-for-storage-local-api/
-   // [-] https://bugzilla.mozilla.org/1488583
-user_pref("dom.indexedDB.enabled", true); // [DEFAULT: true]
-// * * * /
-// FF74
-// 0203: use Mozilla geolocation service instead of Google when geolocation is enabled
-   // Optionally enable logging to the console (defaults to false)
-   // [-] https://bugzilla.mozilla.org/1613627
-user_pref("geo.wifi.uri", "https://location.services.mozilla.com/v1/geolocate?key=%MOZILLA_API_KEY%");
-   // user_pref("geo.wifi.logging.enabled", true); // [HIDDEN PREF]
-// 1704: set behaviour on "+ Tab" button to display container menu [FF53+] [SETUP-CHROME]
-   // 0=no menu (default), 1=show when clicked, 2=show on long press
-   // [1] https://bugzilla.mozilla.org/1328756
-   // [-] https://bugzilla.mozilla.org/1606265
-user_pref("privacy.userContext.longPressBehavior", 2);
-// 2012: limit WebGL
-   // [-] https://bugzilla.mozilla.org/1477756
-user_pref("webgl.disable-extensions", true);
-// * * * /
-// FF76
-// 0401: sanitize blocklist url
-   // [2] https://trac.torproject.org/projects/tor/ticket/16931
-   // [-] https://bugzilla.mozilla.org/1618188
-user_pref("extensions.blocklist.url", "https://blocklists.settings.services.mozilla.com/v1/blocklist/3/%APP_ID%/%APP_VERSION%/");
-// * * * /
-// FF77
-// 0850e: disable location bar one-off searches [FF51+]
-   // [1] https://www.ghacks.net/2016/08/09/firefox-one-off-searches-address-bar/
-   // [-] https://bugzilla.mozilla.org/1628926
-   // user_pref("browser.urlbar.oneOffSearches", false);
-// 2605: block web content in file processes [FF55+]
-   // [SETUP-WEB] You may want to disable this for corporate or developer environments
-   // [1] https://bugzilla.mozilla.org/1343184
-   // [-] https://bugzilla.mozilla.org/1603007
-user_pref("browser.tabs.remote.allowLinkedWebInFileUriProcess", false);
-// * * * /
-// FF78
-// 2031: disable autoplay of HTML5 media if you interacted with the site [FF66+] - replaced by 'media.autoplay.blocking_policy'
-   // [-] https://bugzilla.mozilla.org/1509933
-user_pref("media.autoplay.enabled.user-gestures-needed", false);
-// 5000's: disable chrome animations - replaced FF77+ by 'ui.prefersReducedMotion' (4520)
-   // [-] https://bugzilla.mozilla.org/1640501
-   // user_pref("toolkit.cosmeticAnimations.enabled", false); // [FF55+]
-// * * * /
+// FF79
+// 0212: enforce fallback text encoding to match en-US
+   // When the content or server doesn't declare a charset the browser will
+   // fallback to the "Current locale" based on your application language
+   // [TEST] https://hsivonen.com/test/moz/check-charset.htm
+   // [1] https://gitlab.torproject.org/tpo/applications/tor-browser/-/issues/20025
+   // [-] https://bugzilla.mozilla.org/1603712
+user_pref("intl.charset.fallback.override", "windows-1252");
+// FF82
+// 0206: disable geographically specific results/search engines e.g. "browser.search.*.US"
+   // i.e. ignore all of Mozilla's various search engines in multiple locales
+   // [-] https://bugzilla.mozilla.org/1619926
+user_pref("browser.search.geoSpecificDefaults", false);
+user_pref("browser.search.geoSpecificDefaults.url", "");
+// FF86
+// 1205: disable SSL Error Reporting
+   // [1] https://firefox-source-docs.mozilla.org/main/65.0/browser/base/sslerrorreport/preferences.html
+   // [-] https://bugzilla.mozilla.org/1681839
+user_pref("security.ssl.errorReporting.automatic", false);
+user_pref("security.ssl.errorReporting.enabled", false);
+user_pref("security.ssl.errorReporting.url", "");
+// 2653: disable hiding mime types (Options>General>Applications) not associated with a plugin
+   // [-] https://bugzilla.mozilla.org/1581678
+user_pref("browser.download.hide_plugins_without_extensions", false);
+// FF89
+// 0309: disable sending Flash crash reports
+   // [-] https://bugzilla.mozilla.org/1682030 [underlying NPAPI code removed]
+user_pref("dom.ipc.plugins.flash.subprocess.crashreporter.enabled", false);
+// 0310: disable sending the URL of the website where a plugin crashed
+   // [-] https://bugzilla.mozilla.org/1682030 [underlying NPAPI code removed]
+user_pref("dom.ipc.plugins.reportCrashURL", false);
+// 1243: block unencrypted requests from Flash on encrypted pages to mitigate MitM attacks [FF59+]
+   // [1] https://bugzilla.mozilla.org/1190623
+   // [-] https://bugzilla.mozilla.org/1682030 [underlying NPAPI code removed]
+user_pref("security.mixed_content.block_object_subrequest", true);
+// 1803: disable Flash plugin
+   // 0=deactivated, 1=ask, 2=enabled
+   // ESR52.x is the last branch to fully support NPAPI, FF52+ stable only supports Flash
+   // [NOTE] You can still override individual sites via site permissions
+   // [-] https://bugzilla.mozilla.org/1682030 [underlying NPAPI code removed]
+user_pref("plugin.state.flash", 0); // [DEFAULT: 1]
+// FF90
+// 0708: disable FTP [FF60+]
+   // [-] https://bugzilla.mozilla.org/1574475
+   // user_pref("network.ftp.enabled", false); // [DEFAULT: false FF88+]
 // ***/
 
 /* END: internal custom pref to test for syntax errors ***/

--- a/user.js
+++ b/user.js
@@ -1,6 +1,6 @@
 /******
 * name: thunderbird user.js
-* date: 12 September 2021
+* date: 17 October 2021
 * version: v91-beta
 * url: https://github.com/HorlogeSkynet/thunderbird-user.js
 * license: MIT (https://github.com/HorlogeSkynet/thunderbird-user.js/blob/master/LICENSE)


### PR DESCRIPTION
> ⚠️ **Due to upstream sections "namespace" changes, mail-related preferences sections have been shifted from `6000 / 6100 / 6200 / 6300` to `9100 / 9200 / 9300 / 9400`** ⚠️

## Description
<!--- Describe your changes in detail -->
* Apply Arkenfox `v78..v91` migration
* Global update for v91 ESR
* `[SETTING]` tags global cleanup
* Enable `mailnews.sendformat.auto_downgrade` preference
* Add `mail.phishing.detection.*` preferences
* Remove Autocrypt and Enigmail addons preferences
* Enforce `mail.phishing.detection.*` preferences
* Add `security.osclientcerts.autoload` preference
* Show a prompt when opening a link in external applications as hardening
* Higher `mail.compose.big_attachments.threshold_kb` to 9220KB
* Hide sensitive information from chat desktop notifications (if enabled)
* Clean removed `mail.cloud_files.inserted_urls.footer.link` preference

## Reason and / or context
<!--- Why is this change required ? What problem does it solve ? -->
<!--- If it fixes an open issue, please link to the issue here -->
Thunderbird 91 ESR

## How has this been tested ?
<!--- Include details of your testing environment here -->
Locally, Windows and GNU/Linux.

## Types of changes :
<!--- What types of changes does your code introduce ? Put an `X` in all the boxes that apply : -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Typo / style fix (non-breaking change which improves readability)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- [X] My changes looks good ;
- [X] I agree that my code may be modified in the future ;
- [X] My code follows the code style of this project (see `.eslintrc.yml`).
