### PR TITLE
Thunderbird 102 ESR

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,17 @@
 
 > Thunderbird privacy, security and anti-fingerprinting: a comprehensive user.js template for configuration and hardening
 
-### :purple_square: user.js
+### 🟪 user.js
 
-An `user.js` is a configuration file that can control hundreds of Thunderbird settings.  
-For a more technical breakdown and explanation, you can read more on the [overview](https://github.com/HorlogeSkynet/thunderbird-user.js/wiki/1.1-Overview) Wiki page.
+An `user.js` is a configuration file that can control Thunderbird settings - for a more technical breakdown and explanation, you can read more in the [wiki](https://github.com/HorlogeSkynet/thunderbird-user.js/wiki/1.1-Overview).
 
-### :green_square: Thunderbird user.js
+### 🟩 Thunderbird user.js
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 The `thunderbird user.js` is a **template** which aims to provide as much privacy and enhanced security as possible, and to reduce tracking and fingerprinting as much as possible - while minimizing any loss of functionality and breakage (but it will happen).
 
-Everyone, experts included, should at least read the [implementation](https://github.com/HorlogeSkynet/thunderbird-user.js/wiki/1.3-Implementation) wiki page.
+Everyone, experts included, should at least read the [wiki](https://github.com/HorlogeSkynet/thunderbird-user.js/wiki), as it contains important information regarding a few `user.js` settings.
 
 It differs from the `arkenfox user.js` in that the focus is to keep Thunderbird as an **e-mail client** and disable as many web browsing features as possible. We believe web browsing should be done in a web browser, and not an email client.
 
@@ -22,23 +21,22 @@ It differs from the `arkenfox user.js` in that the focus is to keep Thunderbird 
 - For information about [extensions](https://github.com/HorlogeSkynet/thunderbird-user.js/wiki/4.1-Extensions), see the Wiki.
 - **Calendar** users should [see this page](https://github.com/HorlogeSkynet/thunderbird-user.js/wiki/4.1.1-Calendar).
 
-Also be aware that this `user.js` is made specifically for Thunderbird and has only been tested in the latest stable release.
+Also be aware that this `user.js` is made specifically for Thunderbird and is only being tested against releases with extended support (ESR).
 
-### :orange_square: Sitemap
+### 🟧 Sitemap
 
 - [Releases](https://github.com/HorlogeSkynet/thunderbird-user.js/releases)
 - [Issues](https://github.com/HorlogeSkynet/thunderbird-user.js/issues)
 - [Wiki](https://github.com/HorlogeSkynet/thunderbird-user.js/wiki)
 
-### :red_square: Acknowledgments
+### 🟥 Acknowledgments
 
 * @tya99 most of the ground work and initial port from the Firefox version of [arkenfox user.js](https://github.com/arkenfox/user.js)
 * [@dngray](https://github.com/dngray) continual maintenance and Wiki
 * [@HorlogeSkynet](https://github.com/HorlogeSkynet) continual maintenance
 
-### :blue_square: Related Projects
+### 🟦 Related Projects
 
 * [Privacy Handbuch](https://www.privacy-handbuch.de/handbuch_31p.htm)
 * [Privacy Haters](http://r-36.net/scm/privacy-haters/file/README.md.html)
 * [12bytes.org's user-overrides.js](https://codeberg.org/12bytes.org/thunderbird-user.js-supplement)
-* ~~CHEF-KOCH/TBCK~~

--- a/user.js
+++ b/user.js
@@ -150,7 +150,7 @@ user_pref("toolkit.telemetry.updatePing.enabled", false); // [FF56+]
 user_pref("toolkit.telemetry.bhrPing.enabled", false); // [FF57+] Background Hang Reporter
 user_pref("toolkit.telemetry.firstShutdownPing.enabled", false); // [FF57+]
 /* 0333: disable Telemetry Coverage
-  * [1] https://blog.mozilla.org/data/2018/08/20/effectively-measuring-search-in-firefox/ ***/
+ * [1] https://blog.mozilla.org/data/2018/08/20/effectively-measuring-search-in-firefox/ ***/
 user_pref("toolkit.telemetry.coverage.opt-out", true); // [HIDDEN PREF]
 user_pref("toolkit.coverage.opt-out", true); // [FF64+] [HIDDEN PREF]
 user_pref("toolkit.coverage.endpoint.base", "");
@@ -498,8 +498,8 @@ user_pref("security.cert_pinning.enforcement_level", 2);
 user_pref("security.remote_settings.crlite_filters.enabled", true);
 user_pref("security.pki.crlite_mode", 2);
 /* 1225: enable loading of client certificates stored in OS certificate storage
-  * Bug: this does **NOT** work for S/MIME [1]
-  * [1] https://bugzilla.mozilla.org/show_bug.cgi?id=1726442 ***/
+ * Bug: this does **NOT** work for S/MIME [1]
+ * [1] https://bugzilla.mozilla.org/show_bug.cgi?id=1726442 ***/
    // user_pref("security.osclientcerts.autoload", true);
 
 /** MIXED CONTENT ***/

--- a/user.js
+++ b/user.js
@@ -117,14 +117,7 @@ user_pref("spellchecker.dictionary", "en-US");
  * [1] https://bugzilla.mozilla.org/buglist.cgi?bug_id=867501,1629630 ***/
 user_pref("javascript.use_us_english_locale", true); // [HIDDEN PREF]
 
-/*** [SECTION 0300]: QUIETER BIRD
-     Starting in user.js v68, we only disable the auto-INSTALL of Thunderbird.
-     You still get prompts to update, in one click.
-     We have NEVER disabled auto-CHECKING, and highly discourage that.
-     There are many legitimate reasons to turn off auto-INSTALLS, including hijacked or monetized
-     extensions, time constraints, legacy issues, dev/testing, and fear of breakage/bugs. It is
-     still important to do updates for security reasons, please do so manually if you make changes.
-***/
+/*** [SECTION 0300]: QUIETER BIRD ***/
 user_pref("_user.js.parrot", "0300 syntax error: the parrot's not pinin' for the fjords!");
 /** RECOMMENDATIONS ***/
 /* 0320: disable recommendation pane in about:addons (uses Google Analytics) ***/

--- a/user.js
+++ b/user.js
@@ -1410,6 +1410,9 @@ user_pref("mail.compose.big_attachments.threshold_kb", 9220); // [DEFAULT: 5120]
    // user_pref("mail.compose.warn_public_recipients.threshold", 15); // [DEFAULT: 15]
 /* 9221: Show an alert if the warning above has not been addressed ***/
 user_pref("mail.compose.warn_public_recipients.aggressive", true);
+/* 9222: Disable link previews
+ * [SETTING] Composition > Composition > Add link previews when pasting URLs ***/
+user_pref("mail.compose.add_link_preview", false); // [DEFAULT: false]
 
 /** VIEW ***/
 /* 9230: Disable JavaScript

--- a/user.js
+++ b/user.js
@@ -206,6 +206,8 @@ user_pref("mail.instrumentation.userOptedIn", false);
  * [1] https://searchfox.org/comm-esr102/source/mail/base/content/specialTabs.js#1266 ***/
 user_pref("mail.rights.override", true);  // [DEFAULT: unset]
    // user_pref("mail.rights.version", 1)  // [DEFAULT: unset]
+/* 0372: allow Thunderbird usage without any configured email account [SETUP-INSTALL] ***/
+user_pref("app.use_without_mail_account", true);
 /* 0380: disable the unread message count badge on taskbar icon
  * [1] https://www.thunderbird.net/en-US/thunderbird/91.0.2/releasenotes/#whatsnew */
   // user_pref("mail.biff.show_badge", false); // [WINDOWS]

--- a/user.js
+++ b/user.js
@@ -1383,6 +1383,10 @@ user_pref("mail.compose.big_attachments.notify", true); // [DEFAULT: true]
 /* 9219: Set big attachment size to warn at */
 user_pref("mail.compose.big_attachments.threshold_kb", 9220); // [DEFAULT: 5120]
    // user_pref("mailnews.message_warning_size", 20971520); // [DEFAULT: 20971520]
+/* 9220: Set public recipients number from which BCC is advised ***/
+   // user_pref("mail.compose.warn_public_recipients.threshold", 15); // [DEFAULT: 15]
+/* 9221: Show an alert if the warning above has not been addressed ***/
+user_pref("mail.compose.warn_public_recipients.aggressive", true);
 
 /** VIEW ***/
 /* 9230: Disable JavaScript

--- a/user.js
+++ b/user.js
@@ -1439,6 +1439,9 @@ user_pref("mail.phishing.detection.enabled", true);
 user_pref("mail.phishing.detection.disallow_form_actions", true);
 user_pref("mail.phishing.detection.ipaddresses", true);
 user_pref("mail.phishing.detection.mismatched_hosts", true);
+/* 9250: Disable remote content loading
+ * [SETTING] Privacy & Security > Privacy > Mail content > Allow remote content in messages ***/
+user_pref("mailnews.message_display.disable_remote_image", true); // [DEFAULT: true]
 
 /*** [SECTION 9300]: OTHER THUNDERBIRD COMPONENTS (CHAT / CALENDAR / RSS)
    Options that relate to other Thunderbird components such as the chat client, calendar and RSS)

--- a/user.js
+++ b/user.js
@@ -1,7 +1,7 @@
 /******
 * name: thunderbird user.js
-* date: 24 August 2022
-* version: v102.0-beta1
+* date: 10 September 2022
+* version: v102.0-beta2
 * url: https://github.com/HorlogeSkynet/thunderbird-user.js
 * license: MIT (https://github.com/HorlogeSkynet/thunderbird-user.js/blob/master/LICENSE)
 

--- a/user.js
+++ b/user.js
@@ -344,7 +344,7 @@ user_pref("keyword.enabled", false);  // [DEFAULT: false]
  * as the 411 for DNS errors?), privacy issues (why connect to sites you didn't
  * intend to), can leak sensitive data (e.g. query strings: e.g. Princeton attack),
  * and is a security risk (e.g. common typos & malicious sites set up to exploit this) ***/
-user_pref("browser.fixup.alternate.enabled", false);
+user_pref("browser.fixup.alternate.enabled", false); // [DEFAULT: false FF104+]
 /* 0804: disable live search suggestions
  * [NOTE] Both must be true for the location bar to work
  * [SETUP-CHROME] Override this if you trust and use a privacy respecting search engine ***/
@@ -483,11 +483,10 @@ user_pref("security.OCSP.require", true);
  * 2=detect Family Safety mode and import the root
  * [1] https://gitlab.torproject.org/tpo/applications/tor-browser/-/issues/21686 ***/
 user_pref("security.family_safety.mode", 0);
-/* 1223: enable strict pinning
- * PKP (Public Key Pinning) 0=disabled, 1=allow user MiTM (such as your antivirus), 2=strict
- * [SETUP-WEB] If you rely on an AV (antivirus) to protect your web browsing
- * by inspecting ALL your web traffic, then leave at current default=1
- * [1] https://gitlab.torproject.org/tpo/applications/tor-browser/-/issues/16206 ***/
+/* 1223: enable strict PKP (Public Key Pinning)
+ * 0=disabled, 1=allow user MiTM (default; such as your antivirus), 2=strict
+ * [SETUP-WEB] MOZILLA_PKIX_ERROR_KEY_PINNING_FAILURE: If you rely on an AV (antivirus) to protect
+ * your web browsing by inspecting ALL your web traffic, then override to current default ***/
 user_pref("security.cert_pinning.enforcement_level", 2);
 /* 1224: enable CRLite [FF73+]
  * 0 = disabled
@@ -722,17 +721,26 @@ user_pref("extensions.autoDisableScopes", 15); // [DEFAULT: 15]
 
 /*** [SECTION 2800]: SHUTDOWN & SANITIZING ***/
 user_pref("_user.js.parrot", "2800 syntax error: the parrot's bleedin' demised!");
-/** SANITIZE ON SHUTDOWN: ALLOWS COOKIES + SITE DATA EXCEPTIONS FF102+ ***/
-/* 2810: enable Thunderbird to clear items on shutdown (2811)
- * [NOTE] Exceptions: A "cookie" block permission also controls "offlineApps" (see note in 2811).
- * serviceWorkers require an "Allow" permission. For cross-domain logins, add exceptions for
- * both sites e.g. https://www.youtube.com (site) + https://accounts.google.com (single sign on)
- * [WARNING] Be selective with what cookies you keep, as they also disable partitioning (1767271)
- * [SETTING] Privacy & Security>History>Custom Settings>Clear history when Thunderbird closes
- * [SETTING] to add site exceptions: Ctrl+I>Permissions>Cookies>Allow (when on the website in question)
+/** COOKIES + SITE DATA : ALLOWS EXCEPTIONS ***/
+/* 2801: delete cookies and site data on exit
+ * 0=keep until they expire (default), 2=keep until you close Thunderbird
+ * [NOTE] A "cookie" block permission also controls localStorage/sessionStorage, indexedDB,
+ * sharedWorkers and serviceWorkers. serviceWorkers require an "Allow" permission
+ * [SETTING] Privacy & Security>Cookies and Site Data>Delete cookies and site data when Thunderbird is closed
+ * [SETTING] to add site exceptions: Ctrl+I>Permissions>Cookies>Allow
  * [SETTING] to manage site exceptions: Options>Privacy & Security>Permissions>Settings ***/
+user_pref("network.cookie.lifetimePolicy", 2);
+/* 2802: delete cache on exit [FF96+]
+ * [NOTE] We already disable disk cache (1001) and clear on exit (2811) which is more robust
+ * [1] https://bugzilla.mozilla.org/1671182 ***/
+   // user_pref("privacy.clearsitedata.cache.enabled", true);
+
+/** SANITIZE ON SHUTDOWN : ALL OR NOTHING ***/
+/* 2810: enable Thunderbird to clear items on shutdown (2811)
+ * [SETTING] Privacy & Security>History>Custom Settings>Clear history when Thunderbird closes ***/
 user_pref("privacy.sanitize.sanitizeOnShutdown", true);
 /* 2811: set/enforce what items to clear on shutdown (if 2810 is true) [SETUP-CHROME]
+ * These items do not use exceptions, it is all or nothing (1681701)
  * [NOTE] If "history" is true, downloads will also be cleared
  * [NOTE] "sessions": Active Logins: refers to HTTP Basic Authentication [1], not logins via cookies
  * [NOTE] "offlineApps": Offline Website Data: localStorage, service worker cache, QuotaManager (IndexedDB, asm-cache)
@@ -742,13 +750,9 @@ user_pref("privacy.clearOnShutdown.downloads", true); // [DEFAULT: true]
 user_pref("privacy.clearOnShutdown.formdata", true);  // [DEFAULT: true]
 user_pref("privacy.clearOnShutdown.history", true);   // [DEFAULT: true]
 user_pref("privacy.clearOnShutdown.sessions", true);  // [DEFAULT: true]
-user_pref("privacy.clearOnShutdown.offlineApps", true);
+user_pref("privacy.clearOnShutdown.offlineApps", true); // [DEFAULT: false]
 user_pref("privacy.clearOnShutdown.cookies", true);
-   // user_pref("privacy.clearOnShutdown.siteSettings", false); // [DEFAULT: false]
-/* 2812: delete cache on exit [FF96+]
- * [NOTE] We already disable disk cache (1001) and clear on exit (2811) which is more robust
- * [1] https://bugzilla.mozilla.org/1671182 ***/
-   // user_pref("privacy.clearsitedata.cache.enabled", true);
+   // user_pref("privacy.clearOnShutdown.siteSettings", false);
 
 /** SANITIZE MANUAL: ALL OR NOTHING ***/
 /* 2820: reset default items to clear with Ctrl-Shift-Del [SETUP-CHROME]
@@ -760,15 +764,14 @@ user_pref("privacy.cpd.cache", true);    // [DEFAULT: true]
 user_pref("privacy.cpd.formdata", true); // [DEFAULT: true]
 user_pref("privacy.cpd.history", true);  // [DEFAULT: true]
 user_pref("privacy.cpd.sessions", true); // [DEFAULT: true]
-user_pref("privacy.cpd.offlineApps", false); // [DEFAULT: false]
-user_pref("privacy.cpd.cookies", false);
+user_pref("privacy.cpd.offlineApps", true); // [DEFAULT: false]
+user_pref("privacy.cpd.cookies", true);
    // user_pref("privacy.cpd.downloads", true); // not used, see note above
-   // user_pref("privacy.cpd.passwords", false); // [DEFAULT: false] not listed
-   // user_pref("privacy.cpd.siteSettings", false); // [DEFAULT: false]
+   // user_pref("privacy.cpd.passwords", false);
+   // user_pref("privacy.cpd.siteSettings", false);
 /* 2821: clear Session Restore data when sanitizing on shutdown or manually [FF34+]
  * [NOTE] Not needed if Session Restore is not used (0102) or it is already cleared with history (2811)
- * [NOTE] privacy.clearOnShutdown.openWindows prevents resuming from crashes (also see 5008)
- * [NOTE] privacy.cpd.openWindows has a bug that causes an additional window to open ***/
+ * [NOTE] privacy.clearOnShutdown.openWindows prevents resuming from crashes (also see 5008) ***/
    // user_pref("privacy.clearOnShutdown.openWindows", true);
    // user_pref("privacy.cpd.openWindows", true);
 /* 2822: reset default "Time range to clear" for "Clear Recent History" (2820)
@@ -932,7 +935,8 @@ user_pref("permissions.memory_only", true); // [HIDDEN PREF]
 user_pref("browser.chrome.site_icons", false);
 /* 5007: exclude "Undo Closed Tabs" in Session Restore ***/
 user_pref("browser.sessionstore.max_tabs_undo", 0);
-/* 5008: disable resuming session from crash ***/
+/* 5008: disable resuming session from crash
+ * [TEST] about:crashparent ***/
 user_pref("browser.sessionstore.resume_from_crash", false);
 /* 5009: disable "open with" in download dialog [FF50+]
  * Application data isolation [1]
@@ -1567,10 +1571,6 @@ user_pref("security.ask_for_password", 2);
    // 0902: set how long in minutes Thunderbird should remember the primary password (0901)
    // [-] https://bugzilla.mozilla.org/1767099
 user_pref("security.password_lifetime", 5); // [DEFAULT: 30]
-   // 2801: delete cookies and site data on exit - replaced by sanitizeOnShutdown* (2810)
-   // 0=keep until they expire (default), 2=keep until you close Thunderbird
-   // [-] https://bugzilla.mozilla.org/buglist.cgi?bug_id=1681493,1681495,1681498,1759665
-user_pref("network.cookie.lifetimePolicy", 2);
    // 6007: enforce Local Storage Next Generation (LSNG) [FF65+]
    // [-] https://bugzilla.mozilla.org/1764696
 user_pref("dom.storage.next_gen", true); // [DEFAULT: true FF92+]

--- a/user.js
+++ b/user.js
@@ -1365,6 +1365,7 @@ user_pref("mail.html_compose", false);
 user_pref("mail.identity.default.compose_html", false);
 /* 9213: Send only plaintext email by default
  * [SETUP-FEATURE] Only use HTML email if you need it, see [1]
+ * [SETTING] Composition > Composition > Sending Format
  * Email that is HTML should also have plaintext multipart for plain text users.
  * 0=auto (default, send only plain text if the message is free of any rich formatting
    or inserted elements. Otherwise send both a HTML part and plain text alternative part)

--- a/user.js
+++ b/user.js
@@ -206,6 +206,15 @@ user_pref("app.use_without_mail_account", true);
   // user_pref("mail.biff.show_badge", false); // [WINDOWS]
 /* 0381: show the number of "new" messages on taskbar icon (not the number of unread ones) ***/
   // user_pref("mail.biff.use_new_count_in_badge", true);
+/* 0390: disable new email alerts
+ * [SETTING] General > Incoming Mails > When new messages arrive > Show an alert ***/
+   // user_pref("mail.biff.show_alert", false);
+/* 0391: control the kind of information disclosed in new email alerts
+ * [SETTING] General > Incoming Mails > When new messages arrive > Show an alert > Customize... ***/
+user_pref("mail.biff.alert.show_preview", false);
+user_pref("mail.biff.alert.show_subject", false);
+user_pref("mail.biff.alert.show_sender", false);
+   // user_pref("mail.biff.alert.preview_length", 40);  // [HIDDEN PREF]
 
 /*** [SECTION 0400]: SAFE BROWSING (SB)
    SB has taken many steps to preserve privacy. If required, a full url is never sent

--- a/user.js
+++ b/user.js
@@ -1332,25 +1332,25 @@ user_pref("mail.sanitize_date_header", true);
 /* 9210: Check spelling before sending [SETUP-FEATURE]
  * [1] https://bugzilla.mozilla.org/show_bug.cgi?id=667133 ***/
 user_pref("mail.SpellCheckBeforeSend", false);
-/* 9211: Behavior when sending HTML message [SETUP-FEATURE]
- * (0=Ask, 1=Send as plain text, 2=Send as HTML anyway,
- * 3=Include both plain text and HTML message bodies in message)
- * Email that is HTML should also have plaintext multipart for plain text users.
- * [1] https://drewdevault.com/2016/04/11/Please-use-text-plain-for-emails.html
- * [SETTING] Account Settings > Composition & Addressing > Composition > Compose messages in HTML format ***/
-user_pref("mail.default_html_action", 1);
-/* 9212: Send email in plaintext unless expressly overridden.
+/* 9212: Compose email in plaintext unless expressly overridden
  * [SETUP-FEATURE] Sometimes HTML is useful especially when used with Markdown Here
+ * [SETTING] Account Settings > Composition & Addressing > Composition > Compose messages in HTML format
  * [NOTE] Holding down shift when you click on "Write" will bypass
  * [1] http://kb.mozillazine.org/Plain_text_e-mail_%28Thunderbird%29
  * [2] https://support.mozilla.org/en-US/questions/1004181
  * [3] https://markdown-here.com ***/
 user_pref("mail.html_compose", false);
 user_pref("mail.identity.default.compose_html", false);
-/* 9213: Downgrade email to plaintext by default
- * [SETUP-FEATURE] Only use HTML email if you need it, see above
- * [SETTING] Composition > Composition > HTML Style > Configure text format behavior > Send options... > Send messages as plain text if possible ***/
-user_pref("mailnews.sendformat.auto_downgrade", true);
+/* 9213: Send only plaintext email by default
+ * [SETUP-FEATURE] Only use HTML email if you need it, see [1]
+ * Email that is HTML should also have plaintext multipart for plain text users.
+ * 0=auto (default, send only plain text if the message is free of any rich formatting
+   or inserted elements. Otherwise send both a HTML part and plain text alternative part)
+ * 1=plain text (only send a plain text part, losing any rich formatting or inserted elements)
+ * 2=HTML (only send a HTML part)
+ * 3=both (send both the HTML part and the plain text alternative part)
+ * [1] https://drewdevault.com/2016/04/11/Please-use-text-plain-for-emails.html ***/
+user_pref("mail.default_send_format", 1);
 /* 9214: What classes can process incoming data.
  * (0=All classes (default), 1=Don't display HTML, 2=Don't display HTML and inline images,
  * 3=Don't display HTML, inline images and some other uncommon types, 100=Use a hard coded list)
@@ -1552,6 +1552,17 @@ user_pref("security.csp.enable", true); // [DEFAULT: true]
    // user_pref("network.http.spdy.enabled.deps", false);
    // user_pref("network.http.spdy.enabled.http2", false);
    // user_pref("network.http.spdy.websockets", false); // [FF65+]
+// FF101
+// 9211: Behavior when sending HTML message
+   // (0=Ask, 1=Send as plain text, 2=Send as HTML anyway,
+   // 3=Include both plain text and HTML message bodies in message)
+   // Email that is HTML should also have plaintext multipart for plain text users.
+   // [1] https://drewdevault.com/2016/04/11/Please-use-text-plain-for-emails.html
+   // [-] https://bugzilla.mozilla.org/1727493
+user_pref("mail.default_html_action", 1);
+// 9213: Downgrade email to plaintext by default
+   // [-] https://bugzilla.mozilla.org/1727493
+user_pref("mailnews.sendformat.auto_downgrade", true);
 // FF102
    // 0901: set when Thunderbird should prompt for the primary password
    // 0=once per session (default), 1=every time it's needed, 2=after n minutes (0902)

--- a/user.js
+++ b/user.js
@@ -1446,6 +1446,8 @@ user_pref("mail.chat.notification_info", 2);
  * You may also directly set it to your timezone, i.e. "Pacific/Fakaofo"
  * [SETTING] Calendar > Calendar > Timezone ***/
 user_pref("calendar.timezone.local", "UTC");  // [DEFAULT: ""]
+/* 9313: Disable calendar service performing event "extraction" from email content ***/
+user_pref("calendar.extract.service.enabled", false);  // [DEFAULT: false]
 
 /** RSS ***/
 /** These features don't actually do anything as they aren't implemented

--- a/user.js
+++ b/user.js
@@ -199,8 +199,9 @@ user_pref("mail.instrumentation.userOptedIn", false);
  * [1] https://searchfox.org/comm-esr102/source/mail/base/content/specialTabs.js#1266 ***/
 user_pref("mail.rights.override", true);  // [DEFAULT: unset]
    // user_pref("mail.rights.version", 1)  // [DEFAULT: unset]
-/* 0372: allow Thunderbird usage without any configured email account [SETUP-INSTALL] ***/
-user_pref("app.use_without_mail_account", true);
+/* 0372: allow Thunderbird usage without any configured email account [SETUP-INSTALL]
+ * [NOTE] Only enable this if you don't plan to use emails at all and want to hide the account setup ***/
+   // user_pref("app.use_without_mail_account", true);
 /* 0380: disable the new/unread message count badge on taskbar icon
  * [1] https://www.thunderbird.net/en-US/thunderbird/91.0.2/releasenotes/#whatsnew */
   // user_pref("mail.biff.show_badge", false); // [WINDOWS]

--- a/user.js
+++ b/user.js
@@ -1455,8 +1455,6 @@ user_pref("mail.chat.notification_info", 2);
  * [2] https://bugzilla.mozilla.org/show_bug.cgi?id=1130854
  * [3] https://bugzilla.mozilla.org/show_bug.cgi?id=1130852 ***/
 user_pref("mail.calendar-integration.opt-out", false);
-/* 9311: Set user agent for calendar ***/
-user_pref("calendar.useragent.extra", "");
 /* 9312: Set calendar timezone to avoid system detection [SETUP-INSTALL]
  * By default, extensive system detection would be performed to find user's current timezone.
  * Setting this preference to "UTC" should disable it.

--- a/user.js
+++ b/user.js
@@ -1447,14 +1447,6 @@ user_pref("purple.conversations.im.send_typing", false);
 user_pref("mail.chat.notification_info", 2);
 
 /** CALENDAR ***/
-/* 9310: Disable calendar integration
- * [SETUP-FEATURE] Lightning calendar add-on is integrated in Thunderbird 38 and later.
- * Keeping this preference false allows us to properly show the opt-in/opt-out dialog
- * on new profiles fresh start, see [3].
- * [1] https://bugzilla.mozilla.org/show_bug.cgi?id=401779
- * [2] https://bugzilla.mozilla.org/show_bug.cgi?id=1130854
- * [3] https://bugzilla.mozilla.org/show_bug.cgi?id=1130852 ***/
-user_pref("mail.calendar-integration.opt-out", false);
 /* 9312: Set calendar timezone to avoid system detection [SETUP-INSTALL]
  * By default, extensive system detection would be performed to find user's current timezone.
  * Setting this preference to "UTC" should disable it.

--- a/user.js
+++ b/user.js
@@ -50,6 +50,7 @@
   2000: PLUGINS / MEDIA / WEBRTC
   2400: DOM (DOCUMENT OBJECT MODEL)
   2600: MISCELLANEOUS
+  2700: ETP (ENHANCED TRACKING PROTECTION)
   2800: SHUTDOWN & SANITIZING
   4500: RFP (RESIST FINGERPRINTING)
   5000: OPTIONAL OPSEC
@@ -719,6 +720,18 @@ user_pref("extensions.autoDisableScopes", 15); // [DEFAULT: 15]
 /* 2662: disable webextension restrictions on certain mozilla domains (you also need 4503) [FF60+]
  * [1] https://bugzilla.mozilla.org/buglist.cgi?bug_id=1384330,1406795,1415644,1453988 ***/
    // user_pref("extensions.webextensions.restrictedDomains", "");
+
+/*** [SECTION 2700]: ETP (ENHANCED TRACKING PROTECTION) ***/
+user_pref("_user.js.parrot", "2700 syntax error: the parrot's joined the bleedin' choir invisible!");
+/* 2702: disable ETP web compat features [FF93+]
+ * [SETUP-HARDEN] Includes skip lists, heuristics (SmartBlock) and automatic grants
+ * Opener and redirect heuristics are granted for 30 days, see [3]
+ * [1] https://blog.mozilla.org/security/2021/07/13/smartblock-v2/
+ * [2] https://hg.mozilla.org/mozilla-central/rev/e5483fd469ab#l4.12
+ * [3] https://developer.mozilla.org/en-US/docs/Web/Privacy/State_Partitioning#storage_access_heuristics ***/
+   // user_pref("privacy.antitracking.enableWebcompat", false);
+/* 2710: enable state partitioning of service workers [FF96+] ***/
+user_pref("privacy.partition.serviceWorkers", true);
 
 /*** [SECTION 2800]: SHUTDOWN & SANITIZING ***/
 user_pref("_user.js.parrot", "2800 syntax error: the parrot's bleedin' demised!");

--- a/user.js
+++ b/user.js
@@ -208,9 +208,11 @@ user_pref("mail.rights.override", true);  // [DEFAULT: unset]
    // user_pref("mail.rights.version", 1)  // [DEFAULT: unset]
 /* 0372: allow Thunderbird usage without any configured email account [SETUP-INSTALL] ***/
 user_pref("app.use_without_mail_account", true);
-/* 0380: disable the unread message count badge on taskbar icon
+/* 0380: disable the new/unread message count badge on taskbar icon
  * [1] https://www.thunderbird.net/en-US/thunderbird/91.0.2/releasenotes/#whatsnew */
   // user_pref("mail.biff.show_badge", false); // [WINDOWS]
+/* 0381: show the number of "new" messages on taskbar icon (not the number of unread ones) ***/
+  // user_pref("mail.biff.use_new_count_in_badge", true);
 
 /*** [SECTION 0400]: SAFE BROWSING (SB)
    SB has taken many steps to preserve privacy. If required, a full url is never sent


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
* Arkenfox v91.1 -> v102.1 migration for new ESR
* Adds `app.use_without_mail_account` (v93)
* Enforces `mail.compose.warn_public_recipients.*` preferences (v93) 
* Switches to `mail.default_send_format` to send plaintext email (v101)
* Adds `mail.biff.use_new_count_in_badge` to template
* Gets rid of `mail.calendar-integration.opt-out` & `calendar.useragent.extra`
* Cleans outdated `0300` section documentation (related to auto-install)
* Disables new `calendar.extract.service.enabled` preference
* Adds `mail.biff.show_alert` and `mail.biff.alert.show_*` preferences
* Removes unnecessary leading spaces in some documentation lines
* Enforces `mail.compose.add_link_preview`
* Enforces `mailnews.message_display.disable_remote_image`

## How has this been tested ?
<!--- Include details of your testing environment here -->
* On Windows (Thunderbird v102.2.2)
* On Linux (Thunderbird v102.2.0)

## Types of changes :
<!--- What types of changes does your code introduce ? Put an `X` in all the boxes that apply : -->
- Bug fix (non-breaking change which fixes an issue)
- [X] Typo / style fix (non-breaking change which improves readability)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- [X] My changes looks good ;
- [X] I agree that my code may be modified in the future ;
- [X] My code follows the code style of this project (see `.eslintrc.yml`).
