### PR TITLE
enabled HTML and Text sending

### DIFF
--- a/user.js
+++ b/user.js
@@ -1454,7 +1454,7 @@ user_pref("mail.identity.default.compose_html", false);
  * 2=HTML (only send a HTML part)
  * 3=both (send both the HTML part and the plain text alternative part)
  * [1] https://drewdevault.com/2016/04/11/Please-use-text-plain-for-emails.html ***/
-user_pref("mail.default_send_format", 1);
+user_pref("mail.default_send_format", 3);
 /* 9214: What classes can process incoming data.
  * (0=All classes (default), 1=Don't display HTML, 2=Don't display HTML and inline images,
  * 3=Don't display HTML, inline images and some other uncommon types, 100=Use a hard coded list)


### PR DESCRIPTION
This was really annoying. Sending images as attchments doesnt work as well in Flatpak Thunderbird, an there is little reason to not allow HTML at all.

Poorly there is no "send text, with HTML styles send text and HTML"

<!--- Provide a general summary of your changes in the title above -->


## Description
<!--- Describe your changes in detail -->


## Reason and / or context
<!--- Why is this change required ? What problem does it solve ? -->
<!--- If it fixes an open issue, please link to the issue here -->


## How has this been tested ?
<!--- Include details of your testing environment here -->


## Types of changes :
<!--- What types of changes does your code introduce ? Put an `X` in all the boxes that apply : -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Typo / style fix (non-breaking change which improves readability)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- [x] My changes looks good ;
- [x] I agree that my code may be modified in the future ;
- [ ] My code follows the code style of this project (see `.eslintrc.yml`).
