### PR TITLE
Enables sending HTML emails and "resume from crash"

### DIFF
--- a/user.js
+++ b/user.js
@@ -82,10 +82,10 @@ user_pref("browser.aboutConfig.showWarning", false);
 user_pref("_user.js.parrot", "0100 syntax error: the parrot's dead!");
 /* 0102: set START page [SETUP-CHROME]
  * [SETTING] General > Thunderbird Start Page ***/
-// user_pref("mailnews.start_page.enabled", false);
+user_pref("mailnews.start_page.enabled", false);
 /* 0104: set NEWTAB page
  * true=? (default), false=blank page ***/
-// user_pref("browser.newtabpage.enabled", false);
+user_pref("browser.newtabpage.enabled", false);
 
 /*** [SECTION 0200]: GEOLOCATION / LANGUAGE / LOCALE ***/
 user_pref("_user.js.parrot", "0200 syntax error: the parrot's definitely deceased!");
@@ -567,7 +567,7 @@ user_pref("dom.disable_window_move_resize", true);
 /*** [SECTION 2600]: MISCELLANEOUS ***/
 user_pref("_user.js.parrot", "2600 syntax error: the parrot's run down the curtain!");
 /* 2601: prevent accessibility services from accessing your browser [RESTART]
- * [1] https://support.mozilla.org/en-US/kb/accessibility-services ***/
+ * [1] https://support.mozilla.org/kb/accessibility-services ***/
 user_pref("accessibility.force_disabled", 1);
 /* 2603: remove temp files opened with an external application
  * [1] https://bugzilla.mozilla.org/302433 ***/
@@ -861,7 +861,7 @@ user_pref("browser.chrome.site_icons", false);
 user_pref("browser.sessionstore.max_tabs_undo", 0);
 /* 5008: disable resuming session from crash
  * [TEST] about:crashparent ***/
-// user_pref("browser.sessionstore.resume_from_crash", false);
+    // user_pref("browser.sessionstore.resume_from_crash", false);
 /* 5009: disable "open with" in download dialog [FF50+]
  * Application data isolation [1]
  * [1] https://bugzilla.mozilla.org/1281959 ***/
@@ -1170,7 +1170,7 @@ user_pref("mail.provider.enabled", false);
 /* 9111: Show full email instead of just name from address book
  * true=Show just the display name for people in the address book (default)
  * false=Show both the email address and display name. ***/
-// user_pref("mail.showCondensedAddresses", false);
+user_pref("mail.showCondensedAddresses", false);
 /* 9112: Disable "Filelink for Large Attachments" feature
  * [1] https://support.thunderbird.net/kb/filelink-large-attachments ***/
 user_pref("mail.cloud_files.enabled", false);
@@ -1225,7 +1225,7 @@ user_pref("mailnews.headers.useMinimalUserAgent", true);
  * [SETTING] Preferences > Composition > Addressing > Automatically add outgoing e-mail addresses...
  * [SETTING][CARDBOOK] CardBook > Preferences > Email > Collect Outgoing Email ***/
    // user_pref("mail.collect_addressbook", "jsaddrbook://history.sqlite");
-// user_pref("mail.collect_email_address_outgoing", false);
+user_pref("mail.collect_email_address_outgoing", false);
 /* 9131: Only use email addresses, without their Display Names [CARDBOOK] [SETUP-FEATURE]
  * By default, CardBook extension incorporates contacts display names in addresses fields.
  * This could leak sensitive information to all recipients.
@@ -1267,7 +1267,7 @@ user_pref("mail.sanitize_date_header", true);
  * [1] http://kb.mozillazine.org/Plain_text_e-mail_%28Thunderbird%29
  * [2] https://support.mozilla.org/en-US/questions/1004181
  * [3] https://markdown-here.com ***/
-// user_pref("mail.html_compose", false);
+    // user_pref("mail.html_compose", false);
 user_pref("mail.identity.default.compose_html", false);
 /* 9213: Send only plaintext email by default
  * [SETUP-FEATURE] Only use HTML email if you need it, see [1]
@@ -1279,7 +1279,7 @@ user_pref("mail.identity.default.compose_html", false);
  * 2=HTML (only send a HTML part)
  * 3=both (send both the HTML part and the plain text alternative part)
  * [1] https://drewdevault.com/2016/04/11/Please-use-text-plain-for-emails.html ***/
-user_pref("mail.default_send_format", 0);
+    // user_pref("mail.default_send_format", 0);
 /* 9214: What classes can process incoming data.
  * (0=All classes (default), 1=Don't display HTML, 2=Don't display HTML and inline images,
  * 3=Don't display HTML, inline images and some other uncommon types, 100=Use a hard coded list)

--- a/user.js
+++ b/user.js
@@ -601,7 +601,7 @@ user_pref("network.IDN_show_punycode", true);
  * [SETUP-CHROME] You may prefer a different pdf reader for security/workflow reasons
  * [SETTING] General > Files & Attachments > Portable Document Format (PDF)
  * [1] https://cve.mitre.org/cgi-bin/cvekey.cgi?keyword=pdf.js+firefox ***/
-// user_pref("pdfjs.disabled", false); // [DEFAULT: false]
+user_pref("pdfjs.disabled", false); // [DEFAULT: false]
 user_pref("pdfjs.enableScripting", false); // [FF86+]
 /* 2623: disable permissions delegation [FF73+]
  * Currently applies to cross-origin geolocation, camera, mic and screen-sharing
@@ -1261,16 +1261,16 @@ user_pref("mail.sanitize_date_header", true);
  * [1] https://bugzilla.mozilla.org/show_bug.cgi?id=667133 ***/
    // user_pref("mail.SpellCheckBeforeSend", false);
 /* 9212: Compose email in plaintext unless expressly overridden
- * [SETUP-FEATURE] Sometimes HTML is useful especially when used with Markdown Here
+ * Sometimes HTML is useful especially when used with Markdown Here
  * [SETTING] Account Settings > Composition & Addressing > Composition > Compose messages in HTML format
  * [NOTE] Holding down shift when you click on "Write" will bypass
  * [1] http://kb.mozillazine.org/Plain_text_e-mail_%28Thunderbird%29
  * [2] https://support.mozilla.org/en-US/questions/1004181
  * [3] https://markdown-here.com ***/
-    // user_pref("mail.html_compose", false);
+   // user_pref("mail.html_compose", false);
 user_pref("mail.identity.default.compose_html", false);
 /* 9213: Send only plaintext email by default
- * [SETUP-FEATURE] Only use HTML email if you need it, see [1]
+ * You should only use HTML email if you need it (see [1])
  * [SETTING] Composition > Composition > Sending Format
  * Email that is HTML should also have plaintext multipart for plain text users.
  * 0=auto (default, send only plain text if the message is free of any rich formatting
@@ -1279,14 +1279,14 @@ user_pref("mail.identity.default.compose_html", false);
  * 2=HTML (only send a HTML part)
  * 3=both (send both the HTML part and the plain text alternative part)
  * [1] https://drewdevault.com/2016/04/11/Please-use-text-plain-for-emails.html ***/
-    // user_pref("mail.default_send_format", 0);
-/* 9214: What classes can process incoming data.
+   // user_pref("mail.default_send_format", 0);
+/* 9214: What classes can process incoming data. [SETUP-FEATURE]
  * (0=All classes (default), 1=Don't display HTML, 2=Don't display HTML and inline images,
  * 3=Don't display HTML, inline images and some other uncommon types, 100=Use a hard coded list)
  * In the past this has mitigated a vulnerability CVE-2008-0304 (rare)
  * [1] https://www.mozilla.org/en-US/security/advisories/mfsa2008-12/
  * [2] https://bugzilla.mozilla.org/show_bug.cgi?id=677905 ***/
-// user_pref("mailnews.display.disallow_mime_handlers", 3);
+user_pref("mailnews.display.disallow_mime_handlers", 3);
 /* 9215: How to display HTML parts of a message body
  * (0=Display the HTML normally (default), 1=Convert it to text and then back again
  * 2=Display the HTML source, 3=Sanitize the HTML, 4=Display all body parts)
@@ -1389,7 +1389,7 @@ user_pref("mail.chat.notification_info", 2);
  * [SETTING] Calendar > Calendar > Timezone ***/
 user_pref("calendar.timezone.local", "UTC");  // [DEFAULT: ""]
 /* 9313: Disable calendar service performing event "extraction" from email content ***/
-// user_pref("calendar.extract.service.enabled", false);  // [DEFAULT: false]
+   // user_pref("calendar.extract.service.enabled", false);  // [DEFAULT: false]
 
 /** RSS ***/
 /** These features don't actually do anything as they aren't implemented

--- a/user.js
+++ b/user.js
@@ -567,8 +567,8 @@ user_pref("dom.disable_window_move_resize", true);
 /*** [SECTION 2600]: MISCELLANEOUS ***/
 user_pref("_user.js.parrot", "2600 syntax error: the parrot's run down the curtain!");
 /* 2601: prevent accessibility services from accessing your browser [RESTART]
- * [1] https://support.mozilla.org/kb/accessibility-services ***/
-// user_pref("accessibility.force_disabled", 1);
+ * [1] https://support.mozilla.org/en-US/kb/accessibility-services ***/
+user_pref("accessibility.force_disabled", 1);
 /* 2603: remove temp files opened with an external application
  * [1] https://bugzilla.mozilla.org/302433 ***/
 user_pref("browser.helperApps.deleteTempFileOnExit", true);

--- a/user.js
+++ b/user.js
@@ -850,7 +850,7 @@ user_pref("permissions.memory_only", true); // [HIDDEN PREF]
 /* 5005: disable intermediate certificate caching [FF41+] [RESTART]
  * [NOTE] This affects login/cert/key dbs. The effect is all credentials are session-only.
  * Saved logins and passwords are not available. Reset the pref and restart to return them ***/
-    // user_pref("security.nocertdb", true);
+   // user_pref("security.nocertdb", true);
 /* 5006: disable favicons in history and bookmarks
  * [NOTE] Stored as data blobs in favicons.sqlite, these don't reveal anything that your
  * actual history (and bookmarks) already do. Your history is more detailed, so
@@ -861,7 +861,7 @@ user_pref("browser.chrome.site_icons", false);
 user_pref("browser.sessionstore.max_tabs_undo", 0);
 /* 5008: disable resuming session from crash
  * [TEST] about:crashparent ***/
-    // user_pref("browser.sessionstore.resume_from_crash", false);
+   // user_pref("browser.sessionstore.resume_from_crash", false);
 /* 5009: disable "open with" in download dialog [FF50+]
  * Application data isolation [1]
  * [1] https://bugzilla.mozilla.org/1281959 ***/

--- a/user.js
+++ b/user.js
@@ -82,10 +82,10 @@ user_pref("browser.aboutConfig.showWarning", false);
 user_pref("_user.js.parrot", "0100 syntax error: the parrot's dead!");
 /* 0102: set START page [SETUP-CHROME]
  * [SETTING] General > Thunderbird Start Page ***/
-user_pref("mailnews.start_page.enabled", false);
+// user_pref("mailnews.start_page.enabled", false);
 /* 0104: set NEWTAB page
  * true=? (default), false=blank page ***/
-user_pref("browser.newtabpage.enabled", false);
+// user_pref("browser.newtabpage.enabled", false);
 
 /*** [SECTION 0200]: GEOLOCATION / LANGUAGE / LOCALE ***/
 user_pref("_user.js.parrot", "0200 syntax error: the parrot's definitely deceased!");
@@ -568,7 +568,7 @@ user_pref("dom.disable_window_move_resize", true);
 user_pref("_user.js.parrot", "2600 syntax error: the parrot's run down the curtain!");
 /* 2601: prevent accessibility services from accessing your browser [RESTART]
  * [1] https://support.mozilla.org/kb/accessibility-services ***/
-user_pref("accessibility.force_disabled", 1);
+// user_pref("accessibility.force_disabled", 1);
 /* 2603: remove temp files opened with an external application
  * [1] https://bugzilla.mozilla.org/302433 ***/
 user_pref("browser.helperApps.deleteTempFileOnExit", true);
@@ -601,7 +601,7 @@ user_pref("network.IDN_show_punycode", true);
  * [SETUP-CHROME] You may prefer a different pdf reader for security/workflow reasons
  * [SETTING] General > Files & Attachments > Portable Document Format (PDF)
  * [1] https://cve.mitre.org/cgi-bin/cvekey.cgi?keyword=pdf.js+firefox ***/
-user_pref("pdfjs.disabled", false); // [DEFAULT: false]
+// user_pref("pdfjs.disabled", false); // [DEFAULT: false]
 user_pref("pdfjs.enableScripting", false); // [FF86+]
 /* 2623: disable permissions delegation [FF73+]
  * Currently applies to cross-origin geolocation, camera, mic and screen-sharing
@@ -861,7 +861,7 @@ user_pref("browser.chrome.site_icons", false);
 user_pref("browser.sessionstore.max_tabs_undo", 0);
 /* 5008: disable resuming session from crash
  * [TEST] about:crashparent ***/
-user_pref("browser.sessionstore.resume_from_crash", false);
+// user_pref("browser.sessionstore.resume_from_crash", false);
 /* 5009: disable "open with" in download dialog [FF50+]
  * Application data isolation [1]
  * [1] https://bugzilla.mozilla.org/1281959 ***/
@@ -1170,7 +1170,7 @@ user_pref("mail.provider.enabled", false);
 /* 9111: Show full email instead of just name from address book
  * true=Show just the display name for people in the address book (default)
  * false=Show both the email address and display name. ***/
-user_pref("mail.showCondensedAddresses", false);
+// user_pref("mail.showCondensedAddresses", false);
 /* 9112: Disable "Filelink for Large Attachments" feature
  * [1] https://support.thunderbird.net/kb/filelink-large-attachments ***/
 user_pref("mail.cloud_files.enabled", false);
@@ -1225,7 +1225,7 @@ user_pref("mailnews.headers.useMinimalUserAgent", true);
  * [SETTING] Preferences > Composition > Addressing > Automatically add outgoing e-mail addresses...
  * [SETTING][CARDBOOK] CardBook > Preferences > Email > Collect Outgoing Email ***/
    // user_pref("mail.collect_addressbook", "jsaddrbook://history.sqlite");
-user_pref("mail.collect_email_address_outgoing", false);
+// user_pref("mail.collect_email_address_outgoing", false);
 /* 9131: Only use email addresses, without their Display Names [CARDBOOK] [SETUP-FEATURE]
  * By default, CardBook extension incorporates contacts display names in addresses fields.
  * This could leak sensitive information to all recipients.
@@ -1267,7 +1267,7 @@ user_pref("mail.sanitize_date_header", true);
  * [1] http://kb.mozillazine.org/Plain_text_e-mail_%28Thunderbird%29
  * [2] https://support.mozilla.org/en-US/questions/1004181
  * [3] https://markdown-here.com ***/
-user_pref("mail.html_compose", false);
+// user_pref("mail.html_compose", false);
 user_pref("mail.identity.default.compose_html", false);
 /* 9213: Send only plaintext email by default
  * [SETUP-FEATURE] Only use HTML email if you need it, see [1]
@@ -1279,14 +1279,14 @@ user_pref("mail.identity.default.compose_html", false);
  * 2=HTML (only send a HTML part)
  * 3=both (send both the HTML part and the plain text alternative part)
  * [1] https://drewdevault.com/2016/04/11/Please-use-text-plain-for-emails.html ***/
-user_pref("mail.default_send_format", 1);
+user_pref("mail.default_send_format", 0);
 /* 9214: What classes can process incoming data.
  * (0=All classes (default), 1=Don't display HTML, 2=Don't display HTML and inline images,
  * 3=Don't display HTML, inline images and some other uncommon types, 100=Use a hard coded list)
  * In the past this has mitigated a vulnerability CVE-2008-0304 (rare)
  * [1] https://www.mozilla.org/en-US/security/advisories/mfsa2008-12/
  * [2] https://bugzilla.mozilla.org/show_bug.cgi?id=677905 ***/
-user_pref("mailnews.display.disallow_mime_handlers", 3);
+// user_pref("mailnews.display.disallow_mime_handlers", 3);
 /* 9215: How to display HTML parts of a message body
  * (0=Display the HTML normally (default), 1=Convert it to text and then back again
  * 2=Display the HTML source, 3=Sanitize the HTML, 4=Display all body parts)
@@ -1389,7 +1389,7 @@ user_pref("mail.chat.notification_info", 2);
  * [SETTING] Calendar > Calendar > Timezone ***/
 user_pref("calendar.timezone.local", "UTC");  // [DEFAULT: ""]
 /* 9313: Disable calendar service performing event "extraction" from email content ***/
-user_pref("calendar.extract.service.enabled", false);  // [DEFAULT: false]
+// user_pref("calendar.extract.service.enabled", false);  // [DEFAULT: false]
 
 /** RSS ***/
 /** These features don't actually do anything as they aren't implemented


### PR DESCRIPTION
## Description
removing unneeded lines and changing some settings:

- allow sending mails only when HTML-specific things are actually done
- remove anything regarding "debloat" (Thunderbird news are not bloat...)
- ~enable accessibility (this can still be disabled but it is important for usability)~
- resume from crash
- show condensed address only when in addressbook (this is no spam risk, and TB has GUI configs for that)
- collect addresses of people you write. Mail is not anonymous and stores data, this will make spam detection easier etc
- display inline images etc, this is very limited with sanitized HTML
- allow extracting calendar events, this is by choice via a popup
- enable the new tab page, makes no sense in TB

## Reason and / or context
keep it minimal, dont force unnecessary things on users, making updating complicated

## How has this been tested ?
Thunderbird Flatpak

## Types of changes :
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- [x] My changes looks good ;
- [x] I agree that my code may be modified in the future ;
- [x] My code follows the code style of this project (see `.eslintrc.yml`).
