### PR TITLE
Enforce secure autoconfig and fetching from Exchange

### DIFF
--- a/user.js
+++ b/user.js
@@ -1153,14 +1153,17 @@ user_pref("_user.js.parrot", "9100 syntax error: this parrot is blind!");
  * if the user wishes to keep the existence of the mail provider private.
  * We also enforce (valid) SSL/TLS connections if auto-configuration happens to be enabled.
  * [1] https://developer.mozilla.org/en-US/docs/Mozilla/Thunderbird/Autoconfiguration ***/
-user_pref("mailnews.auto_config.guess.enabled", false);
+// user_pref("mailnews.auto_config.guess.enabled", false);
 user_pref("mailnews.auto_config.fetchFromISP.enabled", false);
 user_pref("mailnews.auto_config.fetchFromISP.sendEmailAddress", false);
-user_pref("mailnews.auto_config.fetchFromExchange.enabled", false);
+// user_pref("mailnews.auto_config.fetchFromExchange.enabled", false);
 user_pref("mailnews.auto_config.guess.sslOnly", true);
 user_pref("mailnews.auto_config.guess.requireGoodCert", true); // [DEFAULT: true]
-user_pref("mailnews.auto_config_url", "");
-user_pref("mailnews.auto_config.addons_url","");
+// user_pref("mailnews.auto_config_url", "");
+// user_pref("mailnews.auto_config.addons_url","");
+user_pref("mailnews.auto_config.fetchFromISP.sslOnly", true);
+user_pref("mailnews.auto_config.fetchFromExchange.sslOnly", true);
+
 /* 9102: Disable account provisioning [SETUP-INSTALL]
  * This option allows users to create a new email account through partner providers.
  * [1] https://developer.mozilla.org/en-US/docs/Mozilla/Thunderbird/Account_Provisioner ***/

--- a/user.js
+++ b/user.js
@@ -1156,13 +1156,12 @@ user_pref("_user.js.parrot", "9100 syntax error: this parrot is blind!");
 // user_pref("mailnews.auto_config.guess.enabled", false);
 user_pref("mailnews.auto_config.fetchFromISP.enabled", false);
 user_pref("mailnews.auto_config.fetchFromISP.sendEmailAddress", false);
-// user_pref("mailnews.auto_config.fetchFromExchange.enabled", false);
+user_pref("mailnews.auto_config.fetchFromISP.sslOnly", true);
+    // user_pref("mailnews.auto_config.fetchFromExchange.enabled", false);
 user_pref("mailnews.auto_config.guess.sslOnly", true);
 user_pref("mailnews.auto_config.guess.requireGoodCert", true); // [DEFAULT: true]
-// user_pref("mailnews.auto_config_url", "");
-// user_pref("mailnews.auto_config.addons_url","");
-user_pref("mailnews.auto_config.fetchFromISP.sslOnly", true);
-user_pref("mailnews.auto_config.fetchFromExchange.sslOnly", true);
+    // user_pref("mailnews.auto_config_url", "https://live.thunderbird.net/autoconfig/v1.1/");
+    // user_pref("mailnews.auto_config.addons_url","https://live.thunderbird.net/autoconfig/addons.json");
 
 /* 9102: Disable account provisioning [SETUP-INSTALL]
  * This option allows users to create a new email account through partner providers.

--- a/user.js
+++ b/user.js
@@ -1152,17 +1152,17 @@ user_pref("_user.js.parrot", "9100 syntax error: this parrot is blind!");
  * Such settings require a query to Mozilla which could have privacy implications
  * if the user wishes to keep the existence of the mail provider private.
  * We also enforce (valid) SSL/TLS connections if auto-configuration happens to be enabled.
+ * If auto-configuration is re-enabled, fetching from Exchange will be allowed by default.
  * [1] https://developer.mozilla.org/en-US/docs/Mozilla/Thunderbird/Autoconfiguration ***/
-// user_pref("mailnews.auto_config.guess.enabled", false);
+user_pref("mailnews.auto_config.guess.enabled", false);
 user_pref("mailnews.auto_config.fetchFromISP.enabled", false);
 user_pref("mailnews.auto_config.fetchFromISP.sendEmailAddress", false);
 user_pref("mailnews.auto_config.fetchFromISP.sslOnly", true);
-    // user_pref("mailnews.auto_config.fetchFromExchange.enabled", false);
+   // user_pref("mailnews.auto_config.fetchFromExchange.enabled", false);
 user_pref("mailnews.auto_config.guess.sslOnly", true);
 user_pref("mailnews.auto_config.guess.requireGoodCert", true); // [DEFAULT: true]
-    // user_pref("mailnews.auto_config_url", "https://live.thunderbird.net/autoconfig/v1.1/");
-    // user_pref("mailnews.auto_config.addons_url","https://live.thunderbird.net/autoconfig/addons.json");
-
+   // user_pref("mailnews.auto_config_url", "https://live.thunderbird.net/autoconfig/v1.1/");
+   // user_pref("mailnews.auto_config.addons_url","https://live.thunderbird.net/autoconfig/addons.json");
 /* 9102: Disable account provisioning [SETUP-INSTALL]
  * This option allows users to create a new email account through partner providers.
  * [1] https://developer.mozilla.org/en-US/docs/Mozilla/Thunderbird/Account_Provisioner ***/


### PR DESCRIPTION
## Description
- enable autoconfig
- allow fetching from Exchange (needed for... exchange servers)
- do not empty the autoconfig and Addon URLs as this is irreversible
- add 2 hardening settings and enable them (even though "fetch from ISP" is still disabled)

## Reason and / or context
Autoconfig is very useful and not critical, as it contacts the mailserver only, to get infos. 

Contacting the ISP, or sending personal data is disabled, and the connection needs to be secure.

## How has this been tested ?
yes, on Thunderbird Flatpak.

## Types of changes :
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist :
- [x] My changes looks good ;
- [x] I agree that my code may be modified in the future ;
- [x] My code follows the code style of this project (see `.eslintrc.yml`).
