### PR TITLE
Enables project notes (start page)

### DIFF
--- a/user.js
+++ b/user.js
@@ -202,7 +202,7 @@ user_pref("mail.rights.override", true);  // [DEFAULT: unset]
  * $url Web page is opened if $viewed is lower than $version (and 0330 policy bypass notification is disabled)
  * [1] https://searchfox.org/comm-esr115/source/mail/base/content/messenger.js#455 ***/
    // user_pref("app.donation.eoy.version", 2);
-   // user_pref("app.donation.eoy.version.viewed", 999);
+user_pref("app.donation.eoy.version.viewed", 999);
    // user_pref("app.donation.eoy.url", "https://www.thunderbird.net/thunderbird/115.0/appeal/");
 /* 0380: disable the new/unread message count badge on taskbar icon
  * [1] https://www.thunderbird.net/en-US/thunderbird/91.0.2/releasenotes/#whatsnew */

--- a/user.js
+++ b/user.js
@@ -82,7 +82,7 @@ user_pref("browser.aboutConfig.showWarning", false);
 user_pref("_user.js.parrot", "0100 syntax error: the parrot's dead!");
 /* 0102: set START page [SETUP-CHROME]
  * [SETTING] General > Thunderbird Start Page ***/
-user_pref("mailnews.start_page.enabled", false);
+// user_pref("mailnews.start_page.enabled", false);
 /* 0104: set NEWTAB page
  * true=? (default), false=blank page ***/
 user_pref("browser.newtabpage.enabled", false);
@@ -202,7 +202,7 @@ user_pref("mail.rights.override", true);  // [DEFAULT: unset]
  * $url Web page is opened if $viewed is lower than $version (and 0330 policy bypass notification is disabled)
  * [1] https://searchfox.org/comm-esr115/source/mail/base/content/messenger.js#455 ***/
    // user_pref("app.donation.eoy.version", 2);
-user_pref("app.donation.eoy.version.viewed", 999);
+// user_pref("app.donation.eoy.version.viewed", 999);
    // user_pref("app.donation.eoy.url", "https://www.thunderbird.net/thunderbird/115.0/appeal/");
 /* 0380: disable the new/unread message count badge on taskbar icon
  * [1] https://www.thunderbird.net/en-US/thunderbird/91.0.2/releasenotes/#whatsnew */

--- a/user.js
+++ b/user.js
@@ -82,7 +82,7 @@ user_pref("browser.aboutConfig.showWarning", false);
 user_pref("_user.js.parrot", "0100 syntax error: the parrot's dead!");
 /* 0102: set START page [SETUP-CHROME]
  * [SETTING] General > Thunderbird Start Page ***/
-// user_pref("mailnews.start_page.enabled", false);
+   // user_pref("mailnews.start_page.enabled", false);
 /* 0104: set NEWTAB page
  * true=? (default), false=blank page ***/
 user_pref("browser.newtabpage.enabled", false);
@@ -202,7 +202,7 @@ user_pref("mail.rights.override", true);  // [DEFAULT: unset]
  * $url Web page is opened if $viewed is lower than $version (and 0330 policy bypass notification is disabled)
  * [1] https://searchfox.org/comm-esr115/source/mail/base/content/messenger.js#455 ***/
    // user_pref("app.donation.eoy.version", 2);
-// user_pref("app.donation.eoy.version.viewed", 999);
+   // user_pref("app.donation.eoy.version.viewed", 999);
    // user_pref("app.donation.eoy.url", "https://www.thunderbird.net/thunderbird/115.0/appeal/");
 /* 0380: disable the new/unread message count badge on taskbar icon
  * [1] https://www.thunderbird.net/en-US/thunderbird/91.0.2/releasenotes/#whatsnew */


### PR DESCRIPTION
## Description
This Mail program was nearly dead. Keeping these "debloating" settings may have a sense, but there is no security impact.

I would be happy to comment these lines out, also because it may be interesting for users to get news from Thunderbird

## Reason and / or context
it is as opinionated as Arkenfox. Disabling any update notifications or donation appeals has no privacy benefit and comes from a really toxic "free as in free beer" perspective.

## How has this been tested ?
It is the default in TB.

## Types of changes :
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- [x] My changes looks good ;
- [x] I agree that my code may be modified in the future ;
- [x] My code follows the code style of this project (see `.eslintrc.yml`).
